### PR TITLE
Introduce a `play` run to execute (and observe) a few trials using any actor implementation

### DIFF
--- a/.env
+++ b/.env
@@ -42,7 +42,8 @@ COGMENT_VERSE_ACTOR_ENDPOINTS="{
 \"td3\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"],
 \"reinforce\": [\"${COGMENT_VERSE_TF_AGENTS_ENDPOINT}\"],
 \"simple_a2c\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"],
-\"simple_bc\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"]
+\"simple_bc\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"],
+\"random\": [\"${COGMENT_VERSE_ENVIRONMENT_ENDPOINT}\"]
 }"
 ## mapping between environment implementations and their endpoint
 COGMENT_VERSE_ENVIRONMENT_ENDPOINTS="{
@@ -89,7 +90,8 @@ COGMENT_VERSE_RUN_ENDPOINTS="{
 \"cogment_verse_run_impl\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"],
 \"reinforce_training\": [\"${COGMENT_VERSE_TF_AGENTS_ENDPOINT}\"],
 \"simple_a2c_training\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"],
-\"simple_bc_training\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"]
+\"simple_bc_training\": [\"${COGMENT_VERSE_TORCH_AGENTS_ENDPOINT}\"],
+\"play\": [\"${COGMENT_VERSE_ENVIRONMENT_ENDPOINT}\"]
 }"
 
 # ENDPOINTS CONFIGURAION (FROM GRAFANA)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ npm_lint:
   script:
     - cd web_client
     - npm install
-    - npx prettier --check .
+    - npm run lint
 
 test_base_python:
   extends: .base_poetry

--- a/README.md
+++ b/README.md
@@ -130,6 +130,46 @@ RUN_PARAMS=benchmark_lander_hill cogment run start_run
 
 Access the playing interface by navigating to <http://localhost:8080>
 
+#### The **Play** run
+
+The **`play`** is a run that is used to test any agent in an environment. The run is started by
+
+```console
+RUN_PARAMS=play cogment run start_run
+```
+
+It can be configured with the following parameters (to change in `run_params.yaml`):
+
+```yaml
+play:
+  implementation: play
+  config:
+    class_name: data_pb2.PlayRunConfig
+    # Set to true to have the ability to observe the run in the web client
+    observer: true
+    # Number of trials to run
+    trial_count: 10
+    environment:
+      # Reference one of the environment specs defined at the top of `run_params.yaml`
+      specs: *cartpole_specs
+    actors:
+    # Configure the players (only the first ones are used, up to the number of required players)
+    ## follows the `cogment_verse.ActorParams` datastructure
+    - name: agent_1
+      actor_class: agent
+      # Select the implementation to use
+      implementation: random
+      agent_config:
+        # Define the agent config here
+        ## follows the `cogment_verse.AgentConfig` datastructure
+        ## Make sure that the selected model is compatible with the selected implementation
+        model_id: compassionate_aryabhata_model
+        model_version: -1
+    - name: agent_2
+      actor_class: agent
+      implementation: random
+```
+
 ## Debug
 
 ### Resources monitoring

--- a/base_python/cogment_verse/agent_adapter.py
+++ b/base_python/cogment_verse/agent_adapter.py
@@ -15,75 +15,117 @@
 import abc
 import logging
 
-from cogment_verse.model_registry_client import get_model_registry_client
-from cogment_verse.utils import LRU
+from cogment_verse.utils import LRU, get_full_class_name
 
 log = logging.getLogger(__name__)
 
 
 class AgentAdapter(abc.ABC):
+    MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY = "_source_adapter_class_name"
+    VERSION_USER_DATA_MODEL_CLASS_NAME_KEY = "_model_class_name"
+
     def __init__(self):
         """
         Create an agent adapter
         """
         self._model_cache = LRU()
+        self._adapter_class_name = get_full_class_name(self)
 
-    @abc.abstractmethod
+        def default_get_model_registry_client():
+            raise RuntimeError("`get_model_registry_client` is not defined before a call to `register_implementations`")
+
+        self.get_model_registry_client = default_get_model_registry_client
+
     def _create(self, model_id, **kwargs):
         """
         Create and return a model instance
         Parameters:
             model_id (string): unique identifier for the model
-            kwargs: any number of key/values paramters
+            kwargs: any number of key/values paramters, forwarded from `create_and_publish_initial_version`
         Returns:
-            model: the created model
+            model, model_user_data: a tuple containing the created model and additional user_data
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
-    def _load(self, model_id, version_number, version_user_data, model_data_f):
+    def __create(self, model_id, **kwargs):
+        model, model_user_data = self._create(model_id, **kwargs)
+        model_user_data[self.MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY] = self._adapter_class_name
+        return model, model_user_data
+
+    def _load(self, model_id, version_number, model_user_data, version_user_data, model_data_f, **kwargs):
         """
         Load a serialized model instance and return it
         Args:
             model_id (string): unique identifier for the model
             version_number (int): version number of the data
+            model_user_data (dict[str, str]): model user data
             version_user_data (dict[str, str]): version user data
             model_data_f: file object that will be used to load the version model data
+            kwargs: any number of key/values parameters, forwarded from `retrieve_version`
         Returns:
             model: the loaded model
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
-    def _save(self, model, model_data_f):
+    def __load(self, model_id, version_number, model_user_data, version_user_data, model_data_f, **kwargs):
+        if (
+            self.MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY in model_user_data
+            and model_user_data[self.MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY] != self._adapter_class_name
+        ):
+            raise RuntimeError(
+                f"Unable to load model '{model_id}@v{version_number}' with adapter '{self._adapter_class_name}': it was initially created by adapter '{model_user_data[self.MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY]}'"
+            )
+
+        return self._load(model_id, version_number, model_user_data, version_user_data, model_data_f, **kwargs)
+
+    def _save(self, model, model_user_data, model_data_f, **kwargs):
         """
         Serialize and save a model
         Args:
-            model: a model, as returned by method of this class
+            model: a model, as returned by the _create method of this class
+            model_user_data (dict[str, str]): model user data
             model_data_f: file object that will be used to save the version model data
+            kwargs: any number of key/values parameters, forwarded from `create_and_publish_initial_version` or `publish_version`
         Returns:
-            version_user_data (dict[str, str]): version user data
+            version_user_data (dict[str, str]): additional version user data
         """
+        raise NotImplementedError
+
+    def __save(self, model, model_user_data, model_data_f, **kwargs):
+        if (
+            self.MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY in model_user_data
+            and model_user_data[self.MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY] != self._adapter_class_name
+        ):
+            raise RuntimeError(
+                f"Unable to save a new version of the model with adapter '{self._adapter_class_name}': it was initially created by adapter '{model_user_data[self.MODEL_USER_DATA_ADAPTER_CLASS_NAME_KEY]}'"
+            )
+
+        version_user_data = self._save(model, model_user_data, model_data_f, **kwargs)
+        version_user_data[self.VERSION_USER_DATA_MODEL_CLASS_NAME_KEY] = get_full_class_name(model)
+
+        return version_user_data
 
     async def create_and_publish_initial_version(self, model_id, **kwargs):
         """
         Create and publish to the model registry a model instance
         Parameters:
             model_id (string): unique identifier for the model
-            kwargs: any number of key/values paramters
+            kwargs: any number of key/values parameters, will be forwarded to `_create`
         Returns:
-            model, version_info: the created model and information for the initial published version
+            model, model_info, version_info: the created model, its information and the information for the initial published version
         """
 
         # Create the agent model locally
-        model = self._create(model_id, **kwargs)
+        model, model_user_data = self.__create(model_id, **kwargs)
 
         # Create it in the model registry
-        await get_model_registry_client().create_model(model_id)
+        await self.get_model_registry_client().create_model(model_id, model_user_data)
 
         # Publish the first version
-        version_info = await self.publish_version(model_id, model)
+        version_info = await self.publish_version(model_id, model, **kwargs)
         return model, version_info
 
-    async def publish_version(self, model_id, model, archived=False):
+    async def publish_version(self, model_id, model, archived=False, **kwargs):
         """
         Publish to the model registry a new version of a model
         Parameters:
@@ -93,21 +135,21 @@ class AgentAdapter(abc.ABC):
         Returns:
             version_info: information for the initial published version
         """
-        return await get_model_registry_client().publish_model_version(
-            model_id, model, self._save, cache=self._model_cache, archived=archived
+        return await self.get_model_registry_client().publish_version(
+            model_id=model_id, model=model, save_model=self.__save, archived=archived, **kwargs
         )
 
-    async def retrieve_version(self, model_id, version_number=-1):
+    async def retrieve_version(self, model_id, version_number=-1, **kwargs):
         """
         Publish to the model registry a new version of a model
         Parameters:
             model_id (string): Unique id of the model
             version_number (int - default is -1): The version number (-1 for the latest)
         Returns:
-            model, version_info: the retrieve model and information for the retrieved version
+            model, model_info, version_info: A tuple containing the model, the model info and the model version info
         """
-        return await get_model_registry_client().retrieve_model_version(
-            model_id, self._load, self._model_cache, version_number=version_number
+        return await self.get_model_registry_client().retrieve_version(
+            model_id=model_id, load_model=self.__load, version_number=version_number, **kwargs
         )
 
     @abc.abstractmethod
@@ -117,6 +159,7 @@ class AgentAdapter(abc.ABC):
         Returns:
             dict[impl_name: string, (actor_impl: Callable, actor_classes: []string)]: key/value definition for the available actor implementations.
         """
+        return {}
 
     @abc.abstractmethod
     def _create_run_implementations(self):
@@ -125,6 +168,7 @@ class AgentAdapter(abc.ABC):
         Returns:
             dict[impl_name: string, (sample_producer_impl: Callable, run_impl: Callable, default_run_config)]: key/value definition for the available run implementations.
         """
+        return {}
 
     def register_implementations(self, context):
         """
@@ -144,3 +188,5 @@ class AgentAdapter(abc.ABC):
                 impl_name=impl_name,
                 default_config=default_config,
             )
+
+        self.get_model_registry_client = context.get_model_registry_client

--- a/base_python/cogment_verse/model_registry_client.py
+++ b/base_python/cogment_verse/model_registry_client.py
@@ -12,23 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import io
 import logging
-import os
 import time
 
 import grpc.aio
+from google.protobuf.json_format import MessageToDict
 from cogment.api.model_registry_pb2 import (
     CreateOrUpdateModelRequest,
     CreateVersionRequestChunk,
     ModelInfo,
     ModelVersionInfo,
+    RetrieveModelsRequest,
     RetrieveVersionDataRequest,
     RetrieveVersionInfosRequest,
 )
 from cogment.api.model_registry_pb2_grpc import ModelRegistrySPStub
-from google.protobuf.json_format import MessageToDict
+from cogment_verse.utils import LRU
 from prometheus_client import Summary
+
 
 MODEL_REGISTRY_PUBLISH_VERSION_TIME = Summary(
     "model_registry_publish_version_seconds",
@@ -45,40 +48,83 @@ log = logging.getLogger(__name__)
 
 
 class ModelRegistryClient:
-    def __init__(self, endpoint):
+    def __init__(self, endpoint, cache=LRU()):
 
         channel = grpc.aio.insecure_channel(endpoint)
         self._stub = ModelRegistrySPStub(channel)
 
-    async def create_model(self, model_id):
+        self._cache = cache
+
+    @staticmethod
+    def _build_model_version_data_cache_key(data_hash):
+        return f"model_version_data_{data_hash}"
+
+    @staticmethod
+    def _build_model_info_cache_key(model_id):
+        return f"model_info_{model_id}"
+
+    async def create_model(self, model_id, model_user_data=None):
         """
         Create a new model in the model registry
 
         Parameters:
-            model_id: The model id
+            model_id (string): The model id
+            model_user_data (dict[str, str] - optional): model user data
         """
+        model_user_data_str = {}
+        if model_user_data:
+            for key, value in model_user_data.items():
+                model_user_data_str[key] = str(value)
 
-        req = CreateOrUpdateModelRequest(model_info=ModelInfo(model_id=model_id))
+        model_info = ModelInfo(model_id=model_id, user_data=model_user_data_str)
+
+        req = CreateOrUpdateModelRequest(model_info=model_info)
         await self._stub.CreateOrUpdateModel(req)
 
-    async def publish_model_version(self, model_id, model, save_model, cache, archived=False):
+        self._cache[self._build_model_info_cache_key(model_id)] = model_info
+
+    async def retrieve_model_info(self, model_id):
+        """
+        Retrieve the given's model information
+
+        Parameters:
+            model_id (string): The model id
+        Returns
+            model_info (dict): The information of the model
+        """
+        cache_key = self._build_model_info_cache_key(model_id)
+
+        if cache_key not in self._cache:
+            req = RetrieveModelsRequest(model_ids=[model_id])
+            rep = await self._stub.RetrieveModels(req)
+
+            model_info = rep.model_infos[0]
+
+            self._cache[cache_key] = model_info
+
+        return MessageToDict(self._cache[cache_key], preserving_proto_field_name=True)
+
+    async def publish_version(self, model_id, model, save_model, archived=False, **kwargs):
         """
         Publish a new version of the model
 
         Parameters:
             model_id (string): Unique id of the model
             model (ModelT): The model
-            save_model (f(ModelT, BinaryIO)): A function able to save the model
-            cache: A dict-like structure used to save the model version locally addressed by its hash
+            save_model (f(ModelT, dict[str, str], BinaryIO, **kwargs) -> dict[str, str]): A function able to save the model, returning version_user_data
             archive (bool - default is False): If true, the model version will be archived (i.e. stored in permanent storage)
+            kwargs: any number of key/values parameters, forwarded to `save_model`
         Returns
             version_info (dict): The information of the published version
         """
 
+        model_info = await self.retrieve_model_info(model_id)
+        model_user_data = model_info["user_data"]
+
         def generate_chunks():
             try:
                 with io.BytesIO() as model_data_io:
-                    version_user_data = save_model(model, model_data_io)
+                    version_user_data = save_model(model, model_user_data, model_data_io, **kwargs)
                     version_data = model_data_io.getvalue()
 
                 version_info = ModelVersionInfo(model_id=model_id, archived=archived, data_size=len(version_data))
@@ -100,54 +146,52 @@ class ModelRegistryClient:
         with MODEL_REGISTRY_PUBLISH_VERSION_TIME.labels(model_id=model_id).time():
             rep = await self._stub.CreateVersion(generate_chunks())
 
-        cache[rep.version_info.data_hash] = model
+        cache_key = self._build_model_version_data_cache_key(rep.version_info.data_hash)
+        self._cache[cache_key] = model
 
         return MessageToDict(rep.version_info, preserving_proto_field_name=True)
 
-    async def retrieve_model_version(self, model_id, load_model, cache, version_number=-1):
+    async def retrieve_version(self, model_id, load_model, version_number=-1, **kwargs):
         """
         Retrieve a version of the model
 
         Parameters:
             model_id (string): Unique id of the model
-            load_model (f(string, int, dict[str, str], BinaryIO)): A function able to load the model
-            cache: A dict-like structure used to retrieve the model version locally addressed by its hash
+            load_model (f(string, int, dict[str, str], dict[str, str], BinaryIO)): A function able to load the model
             version_number (int - default is -1): The version number (-1 for the latest)
+            kwargs: any number of key/values parameters, forwarded to `load_model`
         Returns
-            model: The model at the retrieved version
+            model, model_info, version_info (ModelT, dict[str, str], dict[str, str]): A tuple containing the model version data, the model info and the model version info
         """
         start_time = time.time()
 
-        # First retrieve the model version info
-        req = RetrieveVersionInfosRequest(model_id=model_id, version_numbers=[version_number])
-        rep = await self._stub.RetrieveVersionInfos(req)
-        version_info = rep.version_infos[0]
+        # First retrieve the model info and model version info
+        async def retrieve_version_info(model_id, version_number):
+            req = RetrieveVersionInfosRequest(model_id=model_id, version_numbers=[version_number])
+            rep = await self._stub.RetrieveVersionInfos(req)
+            version_info_pb = rep.version_infos[0]
+            version_info = MessageToDict(version_info_pb, preserving_proto_field_name=True)
+            return version_info
 
-        cached = version_info.data_hash in cache
+        [model_info, version_info] = await asyncio.gather(
+            self.retrieve_model_info(model_id), retrieve_version_info(model_id, version_number)
+        )
 
-        # Check if the model is already in memory, if not retrieve
+        cache_key = self._build_model_version_data_cache_key(version_info["data_hash"])
+        cached = cache_key in self._cache
+
+        # Check if the model version data is already in memory, if not retrieve
         if not cached:
-            req = RetrieveVersionDataRequest(model_id=model_id, version_number=version_info.version_number)
+            req = RetrieveVersionDataRequest(model_id=model_id, version_number=version_info["version_number"])
             data = b""
             async for chunk in self._stub.RetrieveVersionData(req):
                 data += chunk.data_chunk
 
-            version_user_data = {}
-            for key, value in version_info.user_data.items():
-                version_user_data[key] = value
-
             model = load_model(
-                model_id,
-                version_number,
-                version_user_data,
-                io.BytesIO(data),
+                model_id, version_number, model_info["user_data"], version_info["user_data"], io.BytesIO(data), **kwargs
             )
-            cache[version_info.data_hash] = model
+            self._cache[cache_key] = model
 
         MODEL_REGISTRY_RETRIEVE_VERSION_TIME.labels(model_id=model_id, cached=cached).observe(time.time() - start_time)
 
-        return cache[version_info.data_hash], MessageToDict(version_info, preserving_proto_field_name=True)
-
-
-def get_model_registry_client():
-    return ModelRegistryClient(endpoint=os.getenv("COGMENT_VERSE_MODEL_REGISTRY_ENDPOINT"))
+        return self._cache[cache_key], model_info, version_info

--- a/base_python/cogment_verse/model_registry_client.py
+++ b/base_python/cogment_verse/model_registry_client.py
@@ -18,8 +18,14 @@ import os
 import time
 
 import grpc.aio
-from cogment.api.model_registry_pb2 import (CreateOrUpdateModelRequest, CreateVersionRequestChunk, ModelInfo,
-                                            ModelVersionInfo, RetrieveVersionDataRequest, RetrieveVersionInfosRequest)
+from cogment.api.model_registry_pb2 import (
+    CreateOrUpdateModelRequest,
+    CreateVersionRequestChunk,
+    ModelInfo,
+    ModelVersionInfo,
+    RetrieveVersionDataRequest,
+    RetrieveVersionInfosRequest,
+)
 from cogment.api.model_registry_pb2_grpc import ModelRegistrySPStub
 from google.protobuf.json_format import MessageToDict
 from prometheus_client import Summary

--- a/base_python/cogment_verse/run/run_context.py
+++ b/base_python/cogment_verse/run/run_context.py
@@ -62,9 +62,9 @@ class RunContext(cogment.Context):
 
             environment_params = pre_trial_hook_session.trial_config.environment
             pre_trial_hook_session.environment_config = environment_params.config
-            pre_trial_hook_session.environment_implementation = environment_params.implementation
+            pre_trial_hook_session.environment_implementation = environment_params.specs.implementation
             pre_trial_hook_session.environment_endpoint = "grpc://" + self._get_service_endpoint(
-                environment_params.implementation
+                pre_trial_hook_session.environment_implementation
             )
             pre_trial_hook_session.datalog_endpoint = "grpc://" + services_endpoints["trial_datastore"]
             pre_trial_hook_session.actors = [
@@ -75,7 +75,7 @@ class RunContext(cogment.Context):
                     if actor.implementation == "client"
                     else ("grpc://" + self._get_service_endpoint(actor.implementation)),
                     "implementation": "" if actor.implementation == "client" else actor.implementation,
-                    "config": set_config_index(actor.config, actor_idx),
+                    "config": set_config_index(getattr(actor, actor.WhichOneof("config_oneof")), actor_idx),
                 }
                 for actor_idx, actor in enumerate(pre_trial_hook_session.trial_config.actors)
             ]

--- a/base_python/cogment_verse/utils/get_full_class_name.py
+++ b/base_python/cogment_verse/utils/get_full_class_name.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cogment_verse.utils.lru import LRU
-from cogment_verse.utils.sizeof_fmt import sizeof_fmt
-from cogment_verse.utils.throttle import throttle
-from cogment_verse.utils.get_full_class_name import get_full_class_name
+# no import
+
+
+def get_full_class_name(instance):
+    return f"{type(instance).__module__}.{type(instance).__name__}"

--- a/base_python/tests/test_run_config.py
+++ b/base_python/tests/test_run_config.py
@@ -24,7 +24,16 @@ from google.protobuf.json_format import MessageToDict, ParseDict
 @pytest.fixture
 def config_dict():
     config_str = """
-player_count: 1
+environment:
+    specs:
+        implementation: gym/CartPole-v0
+        num_players: 1
+        num_input: 4
+        num_action: 2
+    config:
+        render_width: 256
+        flatten: True
+        framestack: 1
 epsilon_min: 0.1
 epsilon_steps: 100000
 target_net_update_schedule: 1000
@@ -33,23 +42,17 @@ lr_warmup_steps: 10000
 demonstration_count: 0
 total_trial_count: 10000
 model_publication_interval: 1000
-model_archive_interval_multiplier: 4 # Archive every fourth published model
-render_width: 256
+model_archive_interval_multiplier: 4
 batch_size: 256
 min_replay_buffer_size: 1000
 max_parallel_trials: 4
 model_kwargs: {}
 max_replay_buffer_size: 100000
-flatten: True
 aggregate_by_actor: False
-framestack: 1
 replay_buffer_config:
     observation_dtype: float32
     action_dtype: int8
-num_input: 4
-num_action: 2
 agent_implementation: rainbowtorch
-environment_implementation: gym/CartPole-v0
 """
     return yaml.safe_load(config_str)
 
@@ -58,6 +61,6 @@ def test_config(config_dict):
     # should not raise exception
     run_config = ParseDict(config_dict, RunConfig())
     dct = MessageToDict(run_config, preserving_proto_field_name=True)
-    assert "environment_implementation" in dct
+    assert "environment" in dct
     assert "replay_buffer_config" in dct
     assert "observation_dtype" in dct["replay_buffer_config"]

--- a/cogment.yaml
+++ b/cogment.yaml
@@ -80,4 +80,4 @@ actor_classes:
       space: cogment_verse.AgentAction
     observation:
       space: cogment_verse.Observation
-    config_type: cogment_verse.TeacherConfig
+    config_type: cogment_verse.HumanConfig

--- a/cogment.yaml
+++ b/cogment.yaml
@@ -19,7 +19,6 @@ commands:
     torch_agents
     tf_agents
     web_client
-
   build: docker-compose build base_python && docker-compose build
   build_gpu: docker-compose -f docker-compose.yaml -f docker-compose.gpu.yaml build base_python && docker-compose -f docker-compose.yaml -f docker-compose.gpu.yaml build
   start: >
@@ -74,11 +73,11 @@ actor_classes:
       space: cogment_verse.AgentAction
     observation:
       space: cogment_verse.Observation
-    config_type: cogment_verse.ActorConfig
+    config_type: cogment_verse.AgentConfig
 
   - name: teacher_agent
     action:
       space: cogment_verse.AgentAction
     observation:
       space: cogment_verse.Observation
-    config_type: cogment_verse.ActorConfig
+    config_type: cogment_verse.TeacherConfig

--- a/cogment.yaml
+++ b/cogment.yaml
@@ -48,9 +48,9 @@ commands:
   down: docker-compose down
   # Build and use the client
   build_client: docker-compose build client
-  list_runs: docker-compose run client list
-  start_run: docker-compose run client start $RUN_PARAMS
-  terminate_run: docker-compose run client terminate $RUN_ID
+  list_runs: docker-compose run --rm client list
+  start_run: docker-compose run --rm client start $RUN_PARAMS
+  terminate_run: docker-compose run --rm client terminate $RUN_ID
 
   test: cogment run test_torch_agents && cogment run test_environment
   test_torch_agents: >

--- a/cogment.yaml
+++ b/cogment.yaml
@@ -8,7 +8,7 @@ commands:
     cogment copy run_api.proto base_python/cogment_verse/api client
   dev: >
     docker-compose build base_python &&
-    docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up --build --abort-on-container-exit
+    docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up --build
     grafana
     prometheus
     orchestrator

--- a/data.proto
+++ b/data.proto
@@ -51,10 +51,16 @@ message AgentConfig {
   int32 actor_index = 5; // Used to figure out if an agent is the current_player in the observation space
 }
 
+enum HumanRole {
+  TEACHER = 0;
+  OBSERVER = 1;
+}
+
 message HumanConfig {
   string run_id = 1;
   EnvironmentSpecs environment_specs = 2;
   int32 actor_index = 3; // Used to figure out if an agent is the current_player in the observation space
+  HumanRole role = 4;
 }
 
 message ActorParams {
@@ -105,8 +111,8 @@ message ModelArgs {
 }
 
 message ReplayBufferConfig {
-    string action_dtype = 1;
-    string observation_dtype = 2;
+  string action_dtype = 1;
+  string observation_dtype = 2;
 }
 
 message RunConfig {

--- a/data.proto
+++ b/data.proto
@@ -22,7 +22,6 @@ message NDArray {
   bytes data = 3;
 }
 
-
 message EnvironmentConfig {
   string run_id = 1;
   int32 player_count = 2;
@@ -110,32 +109,25 @@ message ReplayBufferConfig {
 }
 
 message RunConfig {
-  string name = 1;
-  uint32 num_input = 2;
-  uint32 num_action = 3;
-  string agent_implementation = 4;
-  string environment_implementation = 5;
-  uint32 player_count = 8;
-  float epsilon_min = 9;
-  uint32 epsilon_steps = 10;
-  uint32 target_net_update_schedule = 11;
-  float learning_rate = 12;
-  uint32 lr_warmup_steps = 13;
-  uint32 demonstration_count = 14;
-  uint32 total_trial_count = 15;
-  uint32 model_publication_interval = 16;
-  uint32 model_archive_interval_multiplier = 17; // Archive every fourth published model
-  uint32 render_width = 18;
-  uint32 batch_size = 19;
-  uint32 min_replay_buffer_size = 20;
-  uint32 max_parallel_trials = 21;
-  ModelArgs model_kwargs = 22;
-  uint32 max_replay_buffer_size = 23;
-  bool flatten = 24;
-  bool aggregate_by_actor = 26;
-  uint32 framestack = 27;
-  ReplayBufferConfig replay_buffer_config = 28;
-  float discount_factor = 29;
+  EnvironmentParams environment = 1;
+  string agent_implementation = 2;
+  float epsilon_min = 3;
+  uint32 epsilon_steps = 4;
+  uint32 target_net_update_schedule = 5;
+  float learning_rate = 6;
+  uint32 lr_warmup_steps = 7;
+  uint32 demonstration_count = 8;
+  uint32 total_trial_count = 9;
+  uint32 model_publication_interval = 10;
+  uint32 model_archive_interval_multiplier = 11; // Archive every fourth published model
+  uint32 batch_size = 12;
+  uint32 min_replay_buffer_size = 13;
+  uint32 max_parallel_trials = 14;
+  ModelArgs model_kwargs = 15;
+  uint32 max_replay_buffer_size = 16;
+  bool aggregate_by_actor = 17;
+  ReplayBufferConfig replay_buffer_config = 18;
+  float discount_factor = 19;
 }
 
 message MLPNetworkConfig {

--- a/data.proto
+++ b/data.proto
@@ -33,25 +33,38 @@ message EnvironmentConfig {
   uint32 seed = 9;
 }
 
-message EnvironmentParams {
+message EnvironmentSpecs {
   string implementation = 1;
-  EnvironmentConfig config = 2;
+  int32 num_input = 2;
+  int32 num_action = 3;
 }
-message ActorConfig {
+
+message EnvironmentParams {
+  EnvironmentSpecs specs = 2; // Keeping that here for the moment, could probably be defined somewhere else with only the implementation name defined in the params
+  EnvironmentConfig config = 3;
+}
+
+message AgentConfig {
   string run_id = 1;
-  string model_id = 2;
-  int32 model_version = 3;
-  int32 num_input = 4;
-  int32 num_action = 5;
-  string environment_implementation = 6; // TODO Remove by retrieving info from the environment instead
-  int32 actor_index = 7; //Used to figure out if an agent is the current_player in the observation space
+  EnvironmentSpecs environment_specs = 2;
+  string model_id = 3;
+  int32 model_version = 4;
+  int32 actor_index = 5; // Used to figure out if an agent is the current_player in the observation space
+}
+
+message TeacherConfig {
+  string run_id = 1;
+  EnvironmentSpecs environment_specs = 2;
 }
 
 message ActorParams {
   string name = 1;
   string actor_class = 2;
   string implementation = 3;
-  ActorConfig config = 4;
+  oneof config_oneof {
+    AgentConfig agent_config = 4;
+    TeacherConfig teacher_config = 5;
+  }
 }
 
 message TrialConfig {
@@ -142,10 +155,9 @@ message SimpleA2CTrainingConfig {
 
 message SimpleA2CTrainingRunConfig {
   EnvironmentParams environment = 1;
-  ActorConfig actor = 2;
-  SimpleA2CTrainingConfig training = 3;
-  MLPNetworkConfig actor_network = 4;
-  MLPNetworkConfig critic_network = 5;
+  SimpleA2CTrainingConfig training = 2;
+  MLPNetworkConfig actor_network = 3;
+  MLPNetworkConfig critic_network = 4;
 }
 
 message SimpleBCTrainingConfig {
@@ -158,7 +170,6 @@ message SimpleBCTrainingConfig {
 
 message SimpleBCTrainingRunConfig {
   EnvironmentParams environment = 1;
-  ActorConfig actor = 2;
-  SimpleBCTrainingConfig training = 3;
-  MLPNetworkConfig policy_network = 4;
+  SimpleBCTrainingConfig training = 2;
+  MLPNetworkConfig policy_network = 3;
 }

--- a/data.proto
+++ b/data.proto
@@ -51,9 +51,10 @@ message AgentConfig {
   int32 actor_index = 5; // Used to figure out if an agent is the current_player in the observation space
 }
 
-message TeacherConfig {
+message HumanConfig {
   string run_id = 1;
   EnvironmentSpecs environment_specs = 2;
+  int32 actor_index = 3; // Used to figure out if an agent is the current_player in the observation space
 }
 
 message ActorParams {
@@ -62,7 +63,7 @@ message ActorParams {
   string implementation = 3;
   oneof config_oneof {
     AgentConfig agent_config = 4;
-    TeacherConfig teacher_config = 5;
+    HumanConfig human_config = 5;
   }
 }
 

--- a/data.proto
+++ b/data.proto
@@ -24,7 +24,6 @@ message NDArray {
 
 message EnvironmentConfig {
   string run_id = 1;
-  int32 player_count = 2;
   bool render = 5;
   bool flatten = 6;
   int32 render_width = 7;
@@ -34,8 +33,9 @@ message EnvironmentConfig {
 
 message EnvironmentSpecs {
   string implementation = 1;
-  int32 num_input = 2;
-  int32 num_action = 3;
+  int32 num_players = 2;
+  int32 num_input = 3;
+  int32 num_action = 4;
 }
 
 message EnvironmentParams {

--- a/data.proto
+++ b/data.proto
@@ -165,3 +165,10 @@ message SimpleBCTrainingRunConfig {
   SimpleBCTrainingConfig training = 2;
   MLPNetworkConfig policy_network = 3;
 }
+
+message PlayRunConfig {
+  EnvironmentParams environment = 1;
+  repeated ActorParams actors = 2;
+  bool observer = 3;
+  uint32 trial_count = 4;
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
 
   orchestrator:
     image: cogment/orchestrator:v2.0.0
+    restart: on-failure
     environment:
-      - COGMENT_VERSE_TRIAL_DATASTORE_ENDPOINT
       - COGMENT_LIFECYCLE_PORT=${COGMENT_VERSE_ORCHESTRATOR_PORT}
       - COGMENT_ACTOR_PORT=${COGMENT_VERSE_ORCHESTRATOR_PORT}
       - COGMENT_PRE_TRIAL_HOOKS=grpc://${COGMENT_VERSE_PRETRIAL_HOOK_ENDPOINT}
@@ -51,6 +51,7 @@ services:
       context: ./environment
       args:
         BASE_PYTHON_IMAGE: cogment/cogment-verse-python-sdk:${IMAGE_TAG:-local}
+    restart: on-failure
     environment:
       - COGMENT_VERSE_ENVIRONMENT_PORT
       - COGMENT_VERSE_ENVIRONMENT_PROMETHEUS_PORT

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,11 @@ services:
     environment:
       - COGMENT_VERSE_ENVIRONMENT_PORT
       - COGMENT_VERSE_ENVIRONMENT_PROMETHEUS_PORT
+      - COGMENT_VERSE_TRIAL_DATASTORE_ENDPOINT
+      - COGMENT_VERSE_ENVIRONMENT_ENDPOINTS
+      - COGMENT_VERSE_ORCHESTRATOR_ENDPOINT
+      - COGMENT_VERSE_ACTOR_ENDPOINTS
+      - MLFLOW_TRACKING_URI
     init: true # xvfb-run hang fix?
     tty: true
 
@@ -76,7 +81,6 @@ services:
       - COGMENT_VERSE_ORCHESTRATOR_ENDPOINT
       - COGMENT_VERSE_ACTOR_ENDPOINTS
       - MLFLOW_TRACKING_URI
-      - MPLBACKEND=Agg
     depends_on:
       - orchestrator
       - environment
@@ -101,7 +105,6 @@ services:
       - COGMENT_VERSE_ORCHESTRATOR_ENDPOINT
       - COGMENT_VERSE_ACTOR_ENDPOINTS
       - MLFLOW_TRACKING_URI
-      - MPLBACKEND=Agg
     depends_on:
       - orchestrator
       - environment

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       - COGMENT_TRIAL_DATASTORE_LOG_LEVEL=info
 
   model_registry:
-    image: cogment/model-registry:v0.4.0
+    image: cogment/model-registry:v0.5.0
     restart: on-failure
     environment:
       - COGMENT_MODEL_REGISTRY_PORT=${COGMENT_VERSE_MODEL_REGISTRY_PORT}

--- a/environment/cogment_verse_environment/atari.py
+++ b/environment/cogment_verse_environment/atari.py
@@ -46,7 +46,6 @@ class AtariEnv(GymEnv):
         screen_size=84,
         sticky_actions=True,
         flatten=True,
-        num_players=1,
         framestack=4,
         **_kwargs,
     ):
@@ -73,7 +72,7 @@ class AtariEnv(GymEnv):
         self._flatten = flatten
         self._last_obs = []  # to be used for framestacking
 
-        super().__init__(env_name=full_env_name, num_players=num_players, framestack=framestack)
+        super().__init__(env_name=full_env_name, num_players=1, framestack=framestack)
 
     def create_env_spec(self, env_name, **_kwargs):
         act_spaces = [self._env.action_space]

--- a/environment/cogment_verse_environment/base.py
+++ b/environment/cogment_verse_environment/base.py
@@ -23,7 +23,7 @@ GymObservation = namedtuple(
 class BaseEnv(ABC):
     def __init__(self, *, env_spec, num_players, framestack):
         self._env_spec = env_spec
-        self._num_players = num_players
+        self.num_players = num_players
         self._turn = 0
         self._framestack = framestack
         assert framestack >= 1

--- a/environment/cogment_verse_environment/base_agent_adapter.py
+++ b/environment/cogment_verse_environment/base_agent_adapter.py
@@ -27,8 +27,9 @@ from data_pb2 import (
     EnvironmentConfig,
     EnvironmentParams,
     EnvironmentSpecs,
-    PlayRunConfig,
     HumanConfig,
+    HumanRole,
+    PlayRunConfig,
     TrialConfig,
 )
 
@@ -116,6 +117,7 @@ class BaseAgentAdapter(AgentAdapter):
                         human_config=HumanConfig(
                             run_id=run_session.run_id,
                             environment_specs=config.environment.specs,
+                            role=HumanRole.OBSERVER,
                         ),
                     )
                 )

--- a/environment/cogment_verse_environment/base_agent_adapter.py
+++ b/environment/cogment_verse_environment/base_agent_adapter.py
@@ -1,0 +1,183 @@
+# Copyright 2021 AI Redefined Inc. <dev+cogment@ai-r.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import copy
+
+import numpy as np
+import cogment
+
+from cogment.api.common_pb2 import TrialState
+from cogment_verse import AgentAdapter, MlflowExperimentTracker
+from data_pb2 import (
+    ActorParams,
+    AgentAction,
+    AgentConfig,
+    EnvironmentConfig,
+    EnvironmentParams,
+    EnvironmentSpecs,
+    PlayRunConfig,
+    TeacherConfig,
+    TrialConfig,
+)
+
+
+log = logging.getLogger(__name__)
+
+# pylint: disable=arguments-differ
+class BaseAgentAdapter(AgentAdapter):
+    def _create(
+        self,
+        model_id,
+        **kwargs,
+    ):
+        raise NotImplementedError
+
+    def _load(self, model_id, version_number, version_user_data, model_data_f):
+        raise NotImplementedError
+
+    def _save(self, model, model_data_f):
+        raise NotImplementedError
+
+    def _create_actor_implementations(self):
+        async def random_impl(actor_session):
+            actor_session.start()
+
+            config = actor_session.config
+
+            async for event in actor_session.event_loop():
+                if event.observation and event.type == cogment.EventType.ACTIVE:
+                    action = np.random.default_rng().integers(0, config.environment_specs.num_action)
+                    actor_session.do_action(AgentAction(discrete_action=action))
+
+        return {
+            "random": (random_impl, ["agent"]),
+        }
+
+    def _create_run_implementations(self):
+        async def total_rewards_producer_impl(run_sample_producer_session):
+            actors_total_rewards = [0.0 for actor_idx in range(run_sample_producer_session.count_actors())]
+            async for sample in run_sample_producer_session.get_all_samples():
+                if sample.get_trial_state() == TrialState.ENDED:
+                    break
+
+                for actor_idx in range(run_sample_producer_session.count_actors()):
+                    actors_total_rewards[actor_idx] += sample.get_actor_reward(actor_idx, 0.0)
+
+            run_sample_producer_session.produce_training_sample(actors_total_rewards)
+
+        async def play_impl(run_session):
+            xp_tracker = MlflowExperimentTracker(run_session.params_name, run_session.run_id)
+
+            config = run_session.config
+            # We ignore additional actor configs
+            if config.environment.config.player_count > len(config.actors):
+                raise RuntimeError(
+                    f"Expecting at least {config.environment.config.player_count} configured actors, got {len(config.actors)}"
+                )
+
+            actors_params = [
+                ActorParams(
+                    name=actor_params.name,
+                    actor_class=actor_params.actor_class,
+                    implementation=actor_params.implementation,
+                    agent_config=AgentConfig(
+                        run_id=run_session.run_id,
+                        environment_specs=config.environment.specs,
+                        model_id=actor_params.agent_config.model_id,
+                        model_version=actor_params.agent_config.model_version,
+                    ),
+                )
+                for actor_params in config.actors[: config.environment.config.player_count]
+            ]
+
+            xp_tracker.log_params(
+                config.environment.config,
+                **{
+                    f"actor_{actor_idx}_implementation": actor_params.implementation
+                    for actor_idx, actor_params in enumerate(actors_params)
+                },
+                **{
+                    f"actor_{actor_idx}_model_id": actor_params.agent_config.model_id
+                    for actor_idx, actor_params in enumerate(actors_params)
+                },
+                **{
+                    f"actor_{actor_idx}_model_version": actor_params.agent_config.model_version
+                    for actor_idx, actor_params in enumerate(actors_params)
+                },
+                environment=config.environment.specs.implementation,
+            )
+
+            if config.observer:
+                # Add an observer agent
+                actors_params.append(
+                    ActorParams(
+                        name="web_actor",
+                        actor_class="teacher_agent",
+                        implementation="client",
+                        teacher_config=TeacherConfig(
+                            run_id=run_session.run_id,
+                            environment_specs=config.environment.specs,
+                        ),
+                    )
+                )
+
+            print("actors_params", actors_params)
+
+            # Helper function to create a trial configuration
+            def create_trial_config(trial_idx):
+                env_params = copy.deepcopy(config.environment)
+                env_params.config.seed = env_params.config.seed + trial_idx
+
+                return TrialConfig(
+                    run_id=run_session.run_id,
+                    environment=env_params,
+                    actors=actors_params,
+                )
+
+            # Rollout a bunch of trials
+            async for (
+                step_idx,
+                step_timestamp,
+                _trial_id,
+                _tick_id,
+                sample,
+            ) in run_session.start_trials_and_wait_for_termination(
+                trial_configs=[create_trial_config(trial_idx) for trial_idx in range(config.trial_count)],
+                max_parallel_trials=1,
+            ):
+                xp_tracker.log_metrics(
+                    step_timestamp,
+                    step_idx,
+                    **{
+                        f"actor_{actor_idx}_reward": sample[actor_idx]
+                        for actor_idx in range(config.environment.config.player_count)
+                    },
+                    total_reward=sum(sample),
+                )
+
+        return {
+            "play": (
+                total_rewards_producer_impl,
+                play_impl,
+                PlayRunConfig(
+                    environment=EnvironmentParams(
+                        specs=EnvironmentSpecs(implementation="gym/LunarLander-v2", num_input=8, num_action=4),
+                        config=EnvironmentConfig(seed=12, player_count=1, framestack=1, render=True, render_width=256),
+                    ),
+                    actors=[],
+                    trial_count=5,
+                ),
+            )
+        }

--- a/environment/cogment_verse_environment/base_agent_adapter.py
+++ b/environment/cogment_verse_environment/base_agent_adapter.py
@@ -82,9 +82,9 @@ class BaseAgentAdapter(AgentAdapter):
 
             config = run_session.config
             # We ignore additional actor configs
-            if config.environment.config.player_count > len(config.actors):
+            if config.environment.specs.num_players > len(config.actors):
                 raise RuntimeError(
-                    f"Expecting at least {config.environment.config.player_count} configured actors, got {len(config.actors)}"
+                    f"Expecting at least {config.environment.specs.num_players} configured actors, got {len(config.actors)}"
                 )
 
             actors_params = [
@@ -99,7 +99,7 @@ class BaseAgentAdapter(AgentAdapter):
                         model_version=actor_params.agent_config.model_version,
                     ),
                 )
-                for actor_params in config.actors[: config.environment.config.player_count]
+                for actor_params in config.actors[: config.environment.specs.num_players]
             ]
 
             xp_tracker.log_params(
@@ -162,7 +162,7 @@ class BaseAgentAdapter(AgentAdapter):
                     step_idx,
                     **{
                         f"actor_{actor_idx}_reward": sample[actor_idx]
-                        for actor_idx in range(config.environment.config.player_count)
+                        for actor_idx in range(config.environment.specs.num_players)
                     },
                     total_reward=sum(sample),
                 )
@@ -173,8 +173,10 @@ class BaseAgentAdapter(AgentAdapter):
                 play_impl,
                 PlayRunConfig(
                     environment=EnvironmentParams(
-                        specs=EnvironmentSpecs(implementation="gym/LunarLander-v2", num_input=8, num_action=4),
-                        config=EnvironmentConfig(seed=12, player_count=1, framestack=1, render=True, render_width=256),
+                        specs=EnvironmentSpecs(
+                            implementation="gym/LunarLander-v2", num_input=8, num_action=4, num_players=1
+                        ),
+                        config=EnvironmentConfig(seed=12, framestack=1, render=True, render_width=256),
                     ),
                     actors=[],
                     trial_count=5,

--- a/environment/cogment_verse_environment/base_agent_adapter.py
+++ b/environment/cogment_verse_environment/base_agent_adapter.py
@@ -28,7 +28,7 @@ from data_pb2 import (
     EnvironmentParams,
     EnvironmentSpecs,
     PlayRunConfig,
-    TeacherConfig,
+    HumanConfig,
     TrialConfig,
 )
 
@@ -37,19 +37,6 @@ log = logging.getLogger(__name__)
 
 # pylint: disable=arguments-differ
 class BaseAgentAdapter(AgentAdapter):
-    def _create(
-        self,
-        model_id,
-        **kwargs,
-    ):
-        raise NotImplementedError
-
-    def _load(self, model_id, version_number, version_user_data, model_data_f):
-        raise NotImplementedError
-
-    def _save(self, model, model_data_f):
-        raise NotImplementedError
-
     def _create_actor_implementations(self):
         async def random_impl(actor_session):
             actor_session.start()
@@ -126,14 +113,12 @@ class BaseAgentAdapter(AgentAdapter):
                         name="web_actor",
                         actor_class="teacher_agent",
                         implementation="client",
-                        teacher_config=TeacherConfig(
+                        human_config=HumanConfig(
                             run_id=run_session.run_id,
                             environment_specs=config.environment.specs,
                         ),
                     )
                 )
-
-            print("actors_params", actors_params)
 
             # Helper function to create a trial configuration
             def create_trial_config(trial_idx):

--- a/environment/cogment_verse_environment/environment_adapter.py
+++ b/environment/cogment_verse_environment/environment_adapter.py
@@ -128,7 +128,6 @@ class EnvironmentAdapter:
                 env = ENVIRONMENT_CONSTRUCTORS[env_type](
                     env_type=env_type,
                     env_name=env_name,
-                    num_players=env_config.player_count,
                     flatten=env_config.flatten,
                     framestack=env_config.framestack,
                 )
@@ -149,10 +148,9 @@ class EnvironmentAdapter:
                 # If there is an extra player, it must be the teacher/expert
                 # and it must be the _last_ player this is only supported form of HILL at the moment)
                 # todo: Make this more general and configurable (via TrialConfig)
-                num_players = env_config.player_count
-                if len(actors) != num_players:
-                    log.debug(len(actors), num_players)
-                    assert len(actors) == num_players + 1
+                if len(actors) != env.num_players:
+                    log.debug(len(actors), env.num_players)
+                    assert len(actors) == env.num_players + 1
                     for idx, actor in enumerate(actors):
                         log.debug(idx, actor.actor_name, actor.actor_class_name)
                     steerable = True

--- a/environment/cogment_verse_environment/gym_env.py
+++ b/environment/cogment_verse_environment/gym_env.py
@@ -78,7 +78,7 @@ class GymEnv(BaseEnv):
 
     def step(self, action=None):
         observation, reward, done, info = self._env.step(action)
-        self._turn = (self._turn + 1) % self._num_players
+        self._turn = (self._turn + 1) % self.num_players
         return GymObservation(
             observation=observation,
             current_player=self._turn,

--- a/environment/cogment_verse_environment/procgen_env.py
+++ b/environment/cogment_verse_environment/procgen_env.py
@@ -57,7 +57,6 @@ class ProcGenEnv(GymEnv):
         frame_skip=1,
         screen_size=64,
         flatten=True,
-        num_players=1,
         framestack=4,
         **_kwargs,
     ):
@@ -77,7 +76,7 @@ class ProcGenEnv(GymEnv):
         self._last_obs = []  # to be used for framestacking
         self._last_pixels = None
 
-        super().__init__(env_name=full_env_name, num_players=num_players, framestack=framestack)
+        super().__init__(env_name=full_env_name, num_players=1, framestack=framestack)
 
     def create_env_spec(self, env_name, **_kwargs):
         act_spaces = [self._env.action_space]

--- a/environment/cogment_verse_environment/procgen_env.py
+++ b/environment/cogment_verse_environment/procgen_env.py
@@ -14,6 +14,7 @@
 
 import cv2
 import numpy as np
+
 # registers procgen environments
 import procgen  # pylint: disable=unused-import
 from cogment_verse_environment.base import GymObservation

--- a/environment/cogment_verse_environment/tetris.py
+++ b/environment/cogment_verse_environment/tetris.py
@@ -33,7 +33,6 @@ class TetrisEnv(AtariEnv):
         screen_size=84,
         _sticky_actions=True,
         flatten=True,
-        num_players=1,
         framestack=4,
         **_kwargs,
     ):  # pylint: disable=super-init-not-called,non-parent-init-called
@@ -52,7 +51,7 @@ class TetrisEnv(AtariEnv):
         self._framestack = framestack
         self._flatten = flatten
 
-        GymEnv.__init__(self, env_name=env_name, num_players=num_players, framestack=framestack)
+        GymEnv.__init__(self, env_name=env_name, num_players=1, framestack=framestack)
 
     def create_env(self, env_name, **_kwargs):
         """Function used to create the environment. Subclasses can override this method

--- a/environment/cogment_verse_environment/zoo_env.py
+++ b/environment/cogment_verse_environment/zoo_env.py
@@ -30,7 +30,7 @@ class PettingZooEnv(GymEnv):
     Class for loading gym built-in environments.
     """
 
-    def __init__(self, *, env_name, num_players=1, flatten=True, **kwargs):
+    def __init__(self, *, env_name, flatten=True, **kwargs):
         """
         Args:
             env_name: Name of the environment (NOTE: make sure it is available at gym.envs.registry.all())
@@ -38,7 +38,8 @@ class PettingZooEnv(GymEnv):
         self._flatten = flatten
         self._cumulative_rewards = None
         self._rewards = None
-        super().__init__(env_name=env_name, num_players=num_players, **kwargs)
+        super().__init__(env_name=env_name, **kwargs)
+        self.num_players = len(self._env.action_spaces)
 
     def create_env(self, env_name, **_kwargs):
         """Function used to create the environment. Subclasses can override this method
@@ -85,8 +86,8 @@ class PettingZooEnv(GymEnv):
 
     def reset(self):
         self._env.reset()
-        self._rewards = np.full(self._num_players, 0.0)
-        self._cumulative_rewards = np.full(self._num_players, 0.0)
+        self._rewards = np.full(self.num_players, 0.0)
+        self._cumulative_rewards = np.full(self.num_players, 0.0)
         self._turn = 0
 
         obs, _, done, info = self._env.last()
@@ -115,7 +116,7 @@ class PettingZooEnv(GymEnv):
         self._rewards = cumulative_rewards - self._cumulative_rewards
         self._cumulative_rewards = cumulative_rewards
 
-        self._turn = (self._turn + 1) % self._num_players
+        self._turn = (self._turn + 1) % self.num_players
 
         return GymObservation(
             observation=self._prepare_obs(obs["observation"]),

--- a/environment/main.py
+++ b/environment/main.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 import asyncio
+import json
 import logging
 import os
 import sys
 
 import cog_settings
 import cogment
+from cogment_verse import RunContext
+from cogment_verse_environment.base_agent_adapter import BaseAgentAdapter
 from cogment_verse_environment.environment_adapter import EnvironmentAdapter
 from dotenv import load_dotenv
 
@@ -27,16 +30,33 @@ load_dotenv()
 PORT = int(os.getenv("COGMENT_VERSE_ENVIRONMENT_PORT", "9000"))
 PROMETHEUS_PORT = int(os.getenv("COGMENT_VERSE_ENVIRONMENT_PROMETHEUS_PORT", "8000"))
 
+TRIAL_DATASTORE_ENDPOINT = os.getenv("COGMENT_VERSE_TRIAL_DATASTORE_ENDPOINT")
+ORCHESTRATOR_ENDPOINT = os.getenv("COGMENT_VERSE_ORCHESTRATOR_ENDPOINT")
+ACTOR_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ACTOR_ENDPOINTS"))
+ENVIRONMENT_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ENVIRONMENT_ENDPOINTS"))
+
 logging.basicConfig(level=logging.INFO)
 
 log = logging.getLogger(__name__)
 
 
 async def main():
-    context = cogment.Context(cog_settings=cog_settings, user_id="cogment_verse_environment")
+    context = RunContext(
+        cog_settings=cog_settings,
+        user_id="cogment_verse_environment",
+        services_endpoints={
+            "orchestrator": ORCHESTRATOR_ENDPOINT,
+            "trial_datastore": TRIAL_DATASTORE_ENDPOINT,
+            **ACTOR_ENDPOINTS,
+            **ENVIRONMENT_ENDPOINTS,
+        },
+    )
 
     environment_adapter = EnvironmentAdapter()
     environment_adapter.register_implementations(context)
+
+    base_agent_adapter = BaseAgentAdapter()
+    base_agent_adapter.register_implementations(context)
 
     log.info(f"Environment service starting on port {PORT}...")
     await context.serve_all_registered(cogment.ServedEndpoint(port=PORT), prometheus_port=PROMETHEUS_PORT)

--- a/environment/main.py
+++ b/environment/main.py
@@ -31,6 +31,7 @@ PORT = int(os.getenv("COGMENT_VERSE_ENVIRONMENT_PORT", "9000"))
 PROMETHEUS_PORT = int(os.getenv("COGMENT_VERSE_ENVIRONMENT_PROMETHEUS_PORT", "8000"))
 
 TRIAL_DATASTORE_ENDPOINT = os.getenv("COGMENT_VERSE_TRIAL_DATASTORE_ENDPOINT")
+MODEL_REGISTRY_ENDPOINT = os.getenv("COGMENT_VERSE_MODEL_REGISTRY_ENDPOINT")
 ORCHESTRATOR_ENDPOINT = os.getenv("COGMENT_VERSE_ORCHESTRATOR_ENDPOINT")
 ACTOR_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ACTOR_ENDPOINTS"))
 ENVIRONMENT_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ENVIRONMENT_ENDPOINTS"))
@@ -47,6 +48,7 @@ async def main():
         services_endpoints={
             "orchestrator": ORCHESTRATOR_ENDPOINT,
             "trial_datastore": TRIAL_DATASTORE_ENDPOINT,
+            "model_registry": MODEL_REGISTRY_ENDPOINT,
             **ACTOR_ENDPOINTS,
             **ENVIRONMENT_ENDPOINTS,
         },
@@ -67,5 +69,5 @@ if __name__ == "__main__":
     try:
         loop.run_until_complete(main())
     except KeyboardInterrupt:
-        print("process interrupted")
+        log.error("process interrupted")
         sys.exit(-1)

--- a/environment/poetry.lock
+++ b/environment/poetry.lock
@@ -1,4 +1,21 @@
 [[package]]
+name = "alembic"
+version = "1.7.6"
+description = "A database migration tool for SQLAlchemy."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.9\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.9\""}
+Mako = "*"
+SQLAlchemy = ">=1.3.0"
+
+[package.extras]
+tz = ["python-dateutil"]
+
+[[package]]
 name = "atari-py"
 version = "0.2.9"
 description = "Python bindings to Atari games"
@@ -41,6 +58,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "cffi"
 version = "1.15.0"
 description = "Foreign Function Interface for Python calling C code."
@@ -50,6 +75,17 @@ python-versions = "*"
 
 [package.dependencies]
 pycparser = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.11"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -72,6 +108,18 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "cmdkit"
+version = "2.6.1"
+description = "A command-line utility toolkit for Python."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+toml = ["toml (>=0.10.1)"]
+yaml = ["pyyaml (>=5.3.1)"]
+
+[[package]]
 name = "cogment"
 version = "2.0.2"
 description = "Cogment python SDK"
@@ -90,6 +138,24 @@ PyYAML = {version = ">=5.3.1,<6.0.0", optional = true, markers = "extra == \"gen
 
 [package.extras]
 generate = ["PyYAML (>=5.3.1,<6.0.0)", "grpcio-tools (==1.38)", "click (>=8.0.3,<9.0.0)"]
+
+[[package]]
+name = "cogment-verse"
+version = "0.1.0"
+description = "cogment verse python SDK"
+category = "main"
+optional = false
+python-versions = ">=3.7,<3.10"
+develop = true
+
+[package.dependencies]
+cogment = {version = "^2.0.2", extras = ["generate"]}
+mlflow = "^1.21.0"
+names-generator = "^0.1.0"
+
+[package.source]
+type = "directory"
+url = "../base_python"
 
 [[package]]
 name = "colorama"
@@ -122,6 +188,45 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "databricks-cli"
+version = "0.16.2"
+description = "A command line interface for Databricks"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+click = ">=6.7"
+requests = ">=2.17.3"
+six = ">=1.10.0"
+tabulate = ">=0.7.7"
+
+[[package]]
+name = "docker"
+version = "5.0.3"
+description = "A Python library for the Docker Engine API."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pywin32 = {version = "227", markers = "sys_platform == \"win32\""}
+requests = ">=2.14.2,<2.18.0 || >2.18.0"
+websocket-client = ">=0.32.0"
+
+[package.extras]
+ssh = ["paramiko (>=2.4.2)"]
+tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=3.4.7)", "idna (>=2.0.0)"]
+
+[[package]]
+name = "entrypoints"
+version = "0.3"
+description = "Discover and load entry points from installed packages."
+category = "main"
+optional = false
+python-versions = ">=2.7"
+
+[[package]]
 name = "filelock"
 version = "3.4.2"
 description = "A platform independent file lock."
@@ -134,8 +239,26 @@ docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
+name = "flask"
+version = "2.0.2"
+description = "A simple framework for building complex web applications."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1.2"
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.0"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
+
+[[package]]
 name = "fonttools"
-version = "4.29.0"
+version = "4.29.1"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
@@ -163,6 +286,29 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "gitdb"
+version = "4.0.9"
+description = "Git Object Database"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.26"
+description = "GitPython is a python library used to interact with Git repositories"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "glcontext"
 version = "2.3.4"
 description = "Portable OpenGL Context"
@@ -177,6 +323,17 @@ description = "A ctypes-based wrapper for GLFW3."
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "greenlet"
+version = "1.1.2"
+description = "Lightweight in-process concurrent programming"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+[package.extras]
+docs = ["sphinx"]
 
 [[package]]
 name = "grpcio"
@@ -215,6 +372,20 @@ python-versions = "*"
 [package.dependencies]
 grpcio = ">=1.38.0"
 protobuf = ">=3.5.0.post1,<4.0dev"
+
+[[package]]
+name = "gunicorn"
+version = "20.1.0"
+description = "WSGI HTTP Server for UNIX"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+eventlet = ["eventlet (>=0.24.1)"]
+gevent = ["gevent (>=1.4.0)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "gym"
@@ -273,6 +444,14 @@ numpy = ">=1.11.0,<2.0.0"
 test = ["pytest (==5.2.1)", "pytest-benchmark (==3.2.2)", "gym-retro (==0.8.0)", "gym (==0.17.2)", "tensorflow (==1.15.0)", "mpi4py (==3.0.3)"]
 
 [[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "imageio"
 version = "2.9.0"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
@@ -317,6 +496,21 @@ perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
+name = "importlib-resources"
+version = "5.4.0"
+description = "Read resources from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -325,12 +519,57 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "itsdangerous"
+version = "2.0.1"
+description = "Safely pass data to untrusted environments and back."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "jinja2"
+version = "3.0.3"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
 name = "kiwisolver"
 version = "1.3.2"
 description = "A fast implementation of the Cassowary constraint solver"
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "mako"
+version = "1.1.6"
+description = "A super-fast templating language that borrows the  best ideas from the existing templating languages."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+MarkupSafe = ">=0.9.2"
+
+[package.extras]
+babel = ["babel"]
+lingua = ["lingua"]
+
+[[package]]
+name = "markupsafe"
+version = "2.0.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "matplotlib"
@@ -383,6 +622,44 @@ reference = "f1387b4123ea5a0203c81b2d3ad9572a8cc578cf"
 resolved_reference = "f1387b4123ea5a0203c81b2d3ad9572a8cc578cf"
 
 [[package]]
+name = "mlflow"
+version = "1.23.1"
+description = "MLflow: A Platform for ML Development and Productionization"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+alembic = "*"
+click = ">=7.0"
+cloudpickle = "*"
+databricks-cli = ">=0.8.7"
+docker = ">=4.0.0"
+entrypoints = "*"
+Flask = "*"
+gitpython = ">=2.1.0"
+gunicorn = {version = "*", markers = "platform_system != \"Windows\""}
+importlib-metadata = ">=3.7.0,<4.7.0 || >4.7.0"
+numpy = "*"
+packaging = "*"
+pandas = "*"
+prometheus-flask-exporter = "*"
+protobuf = ">=3.7.0"
+pytz = "*"
+pyyaml = ">=5.1"
+querystring-parser = "*"
+requests = ">=2.17.3"
+scipy = "*"
+sqlalchemy = "*"
+sqlparse = ">=0.3.1"
+waitress = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+aliyun-oss = ["aliyunstoreplugin"]
+extras = ["scikit-learn", "pyarrow", "boto3", "google-cloud-storage", "azureml-core (>=1.2.0)", "pysftp", "kubernetes", "mlserver (>=0.5.3)", "mlserver-mlflow (>=0.5.3)"]
+sqlserver = ["mlflow-dbstore"]
+
+[[package]]
 name = "moderngl"
 version = "5.6.4"
 description = "ModernGL: High performance rendering for Python 3"
@@ -400,6 +677,17 @@ description = "shlex for windows"
 category = "dev"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "names-generator"
+version = "0.1.0"
+description = "Clone of the Moby/Docker random name generator as a Python package."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+cmdkit = ">=2.1.2"
 
 [[package]]
 name = "nes-py"
@@ -541,8 +829,20 @@ python-versions = "*"
 twisted = ["twisted"]
 
 [[package]]
+name = "prometheus-flask-exporter"
+version = "0.18.7"
+description = "Prometheus metrics exporter for Flask"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+flask = "*"
+prometheus-client = "*"
+
+[[package]]
 name = "protobuf"
-version = "3.19.3"
+version = "3.19.4"
 description = "Protocol Buffers"
 category = "main"
 optional = false
@@ -687,12 +987,49 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pywin32"
+version = "227"
+description = "Python for Window Extensions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[[package]]
+name = "querystring-parser"
+version = "1.2.4"
+description = "QueryString parser for Python/Django that correctly handles nested dictionaries"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
+name = "requests"
+version = "2.27.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "scipy"
@@ -742,6 +1079,66 @@ description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "smmap"
+version = "5.0.0"
+description = "A pure Python implementation of a sliding window memory map manager"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "sqlalchemy"
+version = "1.4.31"
+description = "Database Abstraction Library"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+
+[package.dependencies]
+greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
+aiosqlite = ["typing_extensions (!=3.10.0.1)", "greenlet (!=0.4.17)", "aiosqlite"]
+asyncio = ["greenlet (!=0.4.17)"]
+asyncmy = ["greenlet (!=0.4.17)", "asyncmy (>=0.2.3)"]
+mariadb_connector = ["mariadb (>=1.0.1)"]
+mssql = ["pyodbc"]
+mssql_pymssql = ["pymssql"]
+mssql_pyodbc = ["pyodbc"]
+mypy = ["sqlalchemy2-stubs", "mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0,<2)", "mysqlclient (>=1.4.0)"]
+mysql_connector = ["mysql-connector-python"]
+oracle = ["cx_oracle (>=7,<8)", "cx_oracle (>=7)"]
+postgresql = ["psycopg2 (>=2.7)"]
+postgresql_asyncpg = ["greenlet (!=0.4.17)", "asyncpg"]
+postgresql_pg8000 = ["pg8000 (>=1.16.6)"]
+postgresql_psycopg2binary = ["psycopg2-binary"]
+postgresql_psycopg2cffi = ["psycopg2cffi"]
+pymysql = ["pymysql (<1)", "pymysql"]
+sqlcipher = ["sqlcipher3-binary"]
+
+[[package]]
+name = "sqlparse"
+version = "0.4.2"
+description = "A non-validating SQL parser."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "tabulate"
+version = "0.8.9"
+description = "Pretty-print tabular data"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+widechars = ["wcwidth"]
 
 [[package]]
 name = "taskipy"
@@ -798,6 +1195,31 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "urllib3"
+version = "1.26.8"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "waitress"
+version = "2.0.0"
+description = "Waitress WSGI server"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
+testing = ["pytest", "pytest-cover", "coverage (>=5.0)"]
+
+[[package]]
 name = "watchdog"
 version = "2.1.6"
 description = "Filesystem events monitoring"
@@ -810,6 +1232,30 @@ PyYAML = {version = ">=3.10", optional = true, markers = "extra == \"watchmedo\"
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)"]
+
+[[package]]
+name = "websocket-client"
+version = "1.2.3"
+description = "WebSocket client for Python with low level API options"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
+
+[[package]]
+name = "werkzeug"
+version = "2.0.2"
+description = "The comprehensive WSGI web application library."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+watchdog = ["watchdog"]
 
 [[package]]
 name = "zipp"
@@ -826,9 +1272,13 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "5d356e778a9f781511ea33b29a027b82b80781cab3c69205a64c13c27021dddf"
+content-hash = "94f7661f1a6667edd8c5e105bd8369fe2cb090db7500fa3f6cbc13dfa3e8854c"
 
 [metadata.files]
+alembic = [
+    {file = "alembic-1.7.6-py3-none-any.whl", hash = "sha256:ad842f2c3ab5c5d4861232730779c05e33db4ba880a08b85eb505e87c01095bc"},
+    {file = "alembic-1.7.6.tar.gz", hash = "sha256:6c0c05e9768a896d804387e20b299880fe01bc56484246b0dffe8075d6d3d847"},
+]
 atari-py = [
     {file = "atari-py-0.2.9.tar.gz", hash = "sha256:cb1b4355e3e4b628e272de8317e8dceeadeeabb821b33800409e17ffc3095e20"},
     {file = "atari_py-0.2.9-cp36-cp36m-macosx_10_12_x86_64.whl", hash = "sha256:7a481c265fb58296f96cde0209190ad30640b593cc64611e441782b7884cd185"},
@@ -864,6 +1314,10 @@ box2d-py = [
     {file = "box2d_py-2.3.8-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6c99c75ac75bc9fa98b9914678bff47afddeea2320e7d9956f0859714a8ed579"},
     {file = "box2d_py-2.3.8-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:50cef0925b12d01013dcbe0055ae765b765711b21a324a3eb400ff705a5cc9f6"},
     {file = "box2d_py-2.3.8-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1c1e6b038575ba25dfd95dd3725ceb8602d8376c1e8968a86383982a15cd634"},
+]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
@@ -917,6 +1371,10 @@ cffi = [
     {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
     {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
 ]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
+    {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
+]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
     {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
@@ -925,9 +1383,14 @@ cloudpickle = [
     {file = "cloudpickle-1.6.0-py3-none-any.whl", hash = "sha256:3a32d0eb0bc6f4d0c57fbc4f3e3780f7a81e6fee0fa935072884d58ae8e1cc7c"},
     {file = "cloudpickle-1.6.0.tar.gz", hash = "sha256:9bc994f9e9447593bd0a45371f0e7ac7333710fcf64a4eb9834bf149f4ef2f32"},
 ]
+cmdkit = [
+    {file = "cmdkit-2.6.1-py3-none-any.whl", hash = "sha256:406e81df5d738dd89921c2bfefff1094638d5eccd42b0388e62490cf15dd596a"},
+    {file = "cmdkit-2.6.1.tar.gz", hash = "sha256:ea93d987d749a8cf3c89e9b053d30dfd8736985f94fdc63eb42c86f074d11c86"},
+]
 cogment = [
     {file = "cogment-2.0.2.tar.gz", hash = "sha256:44450745aae6a8b40898e598a278d1cd2752feccb0e890e516e6225d4b9b76ce"},
 ]
+cogment-verse = []
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
@@ -982,16 +1445,40 @@ cycler = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
 ]
+databricks-cli = [
+    {file = "databricks-cli-0.16.2.tar.gz", hash = "sha256:3e9a65a19a589b795ebbd9b3b16a8e470d612d57d6216ae44a9c7a735e4080e6"},
+    {file = "databricks_cli-0.16.2-py2-none-any.whl", hash = "sha256:74c35b38fe686881af4b4797c4f3ab2e1c9e9ff4986f470486f152fb45d19b24"},
+]
+docker = [
+    {file = "docker-5.0.3-py2.py3-none-any.whl", hash = "sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0"},
+    {file = "docker-5.0.3.tar.gz", hash = "sha256:d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb"},
+]
+entrypoints = [
+    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
+    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
 filelock = [
     {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
     {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
 ]
+flask = [
+    {file = "Flask-2.0.2-py3-none-any.whl", hash = "sha256:cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a"},
+    {file = "Flask-2.0.2.tar.gz", hash = "sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2"},
+]
 fonttools = [
-    {file = "fonttools-4.29.0-py3-none-any.whl", hash = "sha256:ed9496e5650b977a697c50ac99c8e8331f9eae3f99e5ae649623359103306dfe"},
-    {file = "fonttools-4.29.0.zip", hash = "sha256:f4834250db2c9855c3385459579dbb5cdf74349ab059ea0e619359b65ae72037"},
+    {file = "fonttools-4.29.1-py3-none-any.whl", hash = "sha256:1933415e0fbdf068815cb1baaa1f159e17830215f7e8624e5731122761627557"},
+    {file = "fonttools-4.29.1.zip", hash = "sha256:2b18a172120e32128a80efee04cff487d5d140fe7d817deb648b2eee023a40e4"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
+gitdb = [
+    {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
+    {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
+]
+gitpython = [
+    {file = "GitPython-3.1.26-py3-none-any.whl", hash = "sha256:26ac35c212d1f7b16036361ca5cff3ec66e11753a0d677fb6c48fa4e1a9dd8d6"},
+    {file = "GitPython-3.1.26.tar.gz", hash = "sha256:fc8868f63a2e6d268fb25f481995ba185a85a66fcad126f039323ff6635669ee"},
 ]
 glcontext = [
     {file = "glcontext-2.3.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e558960888be5a4aa8e2f6f43b5320a227c8519bc3517bf7202cb40925114a6d"},
@@ -1025,6 +1512,58 @@ glfw = [
     {file = "glfw-1.12.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38-none-win32.whl", hash = "sha256:fe9622a48ec9dc436e67de0d0bb4c9443996b5bd5564df1734d3a4280b728d38"},
     {file = "glfw-1.12.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38-none-win_amd64.whl", hash = "sha256:3723db5e5628b2cd8729421fb6fc5fed3e5d25c7d1631f72f13301b218ee1600"},
     {file = "glfw-1.12.0.tar.gz", hash = "sha256:f195ed7a43475e4f1603903d6999f3a6b470fda88bd1749ff10adc520abe8fb1"},
+]
+greenlet = [
+    {file = "greenlet-1.1.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:58df5c2a0e293bf665a51f8a100d3e9956febfbf1d9aaf8c0677cf70218910c6"},
+    {file = "greenlet-1.1.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:aec52725173bd3a7b56fe91bc56eccb26fbdff1386ef123abb63c84c5b43b63a"},
+    {file = "greenlet-1.1.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:833e1551925ed51e6b44c800e71e77dacd7e49181fdc9ac9a0bf3714d515785d"},
+    {file = "greenlet-1.1.2-cp27-cp27m-win32.whl", hash = "sha256:aa5b467f15e78b82257319aebc78dd2915e4c1436c3c0d1ad6f53e47ba6e2713"},
+    {file = "greenlet-1.1.2-cp27-cp27m-win_amd64.whl", hash = "sha256:40b951f601af999a8bf2ce8c71e8aaa4e8c6f78ff8afae7b808aae2dc50d4c40"},
+    {file = "greenlet-1.1.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:95e69877983ea39b7303570fa6760f81a3eec23d0e3ab2021b7144b94d06202d"},
+    {file = "greenlet-1.1.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:356b3576ad078c89a6107caa9c50cc14e98e3a6c4874a37c3e0273e4baf33de8"},
+    {file = "greenlet-1.1.2-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8639cadfda96737427330a094476d4c7a56ac03de7265622fcf4cfe57c8ae18d"},
+    {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497"},
+    {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1"},
+    {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58"},
+    {file = "greenlet-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708"},
+    {file = "greenlet-1.1.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23"},
+    {file = "greenlet-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee"},
+    {file = "greenlet-1.1.2-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c"},
+    {file = "greenlet-1.1.2-cp35-cp35m-win32.whl", hash = "sha256:7cbd7574ce8e138bda9df4efc6bf2ab8572c9aff640d8ecfece1b006b68da963"},
+    {file = "greenlet-1.1.2-cp35-cp35m-win_amd64.whl", hash = "sha256:903bbd302a2378f984aef528f76d4c9b1748f318fe1294961c072bdc7f2ffa3e"},
+    {file = "greenlet-1.1.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:049fe7579230e44daef03a259faa24511d10ebfa44f69411d99e6a184fe68073"},
+    {file = "greenlet-1.1.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:dd0b1e9e891f69e7675ba5c92e28b90eaa045f6ab134ffe70b52e948aa175b3c"},
+    {file = "greenlet-1.1.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7418b6bfc7fe3331541b84bb2141c9baf1ec7132a7ecd9f375912eca810e714e"},
+    {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce"},
+    {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08"},
+    {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168"},
+    {file = "greenlet-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa"},
+    {file = "greenlet-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d"},
+    {file = "greenlet-1.1.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4"},
+    {file = "greenlet-1.1.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b"},
+    {file = "greenlet-1.1.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:93f81b134a165cc17123626ab8da2e30c0455441d4ab5576eed73a64c025b25c"},
+    {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1"},
+    {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28"},
+    {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5"},
+    {file = "greenlet-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc"},
+    {file = "greenlet-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06"},
+    {file = "greenlet-1.1.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0"},
+    {file = "greenlet-1.1.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:eb6ea6da4c787111adf40f697b4e58732ee0942b5d3bd8f435277643329ba627"},
+    {file = "greenlet-1.1.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f3acda1924472472ddd60c29e5b9db0cec629fbe3c5c5accb74d6d6d14773478"},
+    {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43"},
+    {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711"},
+    {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b"},
+    {file = "greenlet-1.1.2-cp38-cp38-win32.whl", hash = "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd"},
+    {file = "greenlet-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3"},
+    {file = "greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67"},
+    {file = "greenlet-1.1.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:572e1787d1460da79590bf44304abbc0a2da944ea64ec549188fa84d89bba7ab"},
+    {file = "greenlet-1.1.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:be5f425ff1f5f4b3c1e33ad64ab994eed12fc284a6ea71c5243fd564502ecbe5"},
+    {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88"},
+    {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b"},
+    {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3"},
+    {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
+    {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
+    {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
 ]
 grpcio = [
     {file = "grpcio-1.38.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:118479436bda25b369e2dc1cd0921790fbfaea1ec663e4ee7095c4c325694495"},
@@ -1137,6 +1676,10 @@ grpcio-tools = [
     {file = "grpcio_tools-1.38.0-cp39-cp39-win32.whl", hash = "sha256:1be89cc16be3984b43e40ea456e9e5428561987e99da2d79c1fc2629e87b6438"},
     {file = "grpcio_tools-1.38.0-cp39-cp39-win_amd64.whl", hash = "sha256:405a70b315970523c35bb487b1533a22ff4a126c649f074b4df49cb1e304561d"},
 ]
+gunicorn = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+]
 gym = [
     {file = "gym-0.18.0.tar.gz", hash = "sha256:a0dcd25c1373f3938f4cb4565f74f434fba6faefb73a42d09c9dddd0c08af53e"},
 ]
@@ -1146,6 +1689,10 @@ gym-tetris = [
 ]
 gym3 = [
     {file = "gym3-0.3.3-py3-none-any.whl", hash = "sha256:bacc0e124f8ce5e1d8a9dceb85725123332954f13ef4e226133506597548838a"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 imageio = [
     {file = "imageio-2.9.0-py3-none-any.whl", hash = "sha256:3604d751f03002e8e0e7650aa71d8d9148144a87daf17cb1f3228e80747f2e6b"},
@@ -1162,9 +1709,21 @@ importlib-metadata = [
     {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
     {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
 ]
+importlib-resources = [
+    {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
+    {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
+]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+itsdangerous = [
+    {file = "itsdangerous-2.0.1-py3-none-any.whl", hash = "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c"},
+    {file = "itsdangerous-2.0.1.tar.gz", hash = "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"},
+]
+jinja2 = [
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 kiwisolver = [
     {file = "kiwisolver-1.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1d819553730d3c2724582124aee8a03c846ec4362ded1034c16fb3ef309264e6"},
@@ -1212,6 +1771,46 @@ kiwisolver = [
     {file = "kiwisolver-1.3.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bcadb05c3d4794eb9eee1dddf1c24215c92fb7b55a80beae7a60530a91060560"},
     {file = "kiwisolver-1.3.2.tar.gz", hash = "sha256:fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c"},
 ]
+mako = [
+    {file = "Mako-1.1.6-py2.py3-none-any.whl", hash = "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"},
+    {file = "Mako-1.1.6.tar.gz", hash = "sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
+    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
+]
 matplotlib = [
     {file = "matplotlib-3.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:456cc8334f6d1124e8ff856b42d2cc1c84335375a16448189999496549f7182b"},
     {file = "matplotlib-3.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8a77906dc2ef9b67407cec0bdbf08e3971141e535db888974a915be5e1e3efc6"},
@@ -1250,6 +1849,10 @@ matplotlib = [
     {file = "matplotlib-3.5.1.tar.gz", hash = "sha256:b2e9810e09c3a47b73ce9cab5a72243a1258f61e7900969097a817232246ce1c"},
 ]
 MinAtar = []
+mlflow = [
+    {file = "mlflow-1.23.1-py3-none-any.whl", hash = "sha256:14d2b758f20d9172fc72237759d743dea233b9b698f58f770e76503a7a713fdc"},
+    {file = "mlflow-1.23.1.tar.gz", hash = "sha256:be64c34749965ffa8aed4db5113b57e3df2479abe5f00ffe0d6bed1329f42e0f"},
+]
 moderngl = [
     {file = "moderngl-5.6.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_27_x86_64.whl", hash = "sha256:792ffe1ec233ed5fcfb0c14955a7f944d64c0d49713ff8b9c5fa3176d96f05c3"},
     {file = "moderngl-5.6.4-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:1f9ed0bc0d706124a01be2ad59b5774bb3b023e61dcf39faf7c4c7ef4b9f4f75"},
@@ -1282,6 +1885,10 @@ moderngl = [
 mslex = [
     {file = "mslex-0.3.0-py2.py3-none-any.whl", hash = "sha256:380cb14abf8fabf40e56df5c8b21a6d533dc5cbdcfe42406bbf08dda8f42e42a"},
     {file = "mslex-0.3.0.tar.gz", hash = "sha256:4a1ac3f25025cad78ad2fe499dd16d42759f7a3801645399cce5c404415daa97"},
+]
+names-generator = [
+    {file = "names_generator-0.1.0-py3-none-any.whl", hash = "sha256:8fec2903c71204b64bbb12f2cce0fdabdcde2aa83ebea29025c7b6f62b55832b"},
+    {file = "names_generator-0.1.0.tar.gz", hash = "sha256:03d0deb20e4c179688018103eaee4004ac2b8d8ccc1f8152272f75168b6a0b41"},
 ]
 nes-py = [
     {file = "nes_py-8.1.8-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:2c3183cbb689eb609351dd71bf05a27d0c34d3c65896e453e5b35106ba8cb2d9"},
@@ -1413,33 +2020,37 @@ prometheus-client = [
     {file = "prometheus_client-0.8.0-py2.py3-none-any.whl", hash = "sha256:983c7ac4b47478720db338f1491ef67a100b474e3bc7dafcbaefb7d0b8f9b01c"},
     {file = "prometheus_client-0.8.0.tar.gz", hash = "sha256:c6e6b706833a6bd1fd51711299edee907857be10ece535126a158f911ee80915"},
 ]
+prometheus-flask-exporter = [
+    {file = "prometheus_flask_exporter-0.18.7-py3-none-any.whl", hash = "sha256:38bc68db295d0f895ad0fb319b1bfd200ae273b33397ce497c9b96dceb708ce9"},
+    {file = "prometheus_flask_exporter-0.18.7.tar.gz", hash = "sha256:f1f6f23535479d41587a100a24a60cb9199c34986e95f6691496807ee5017e59"},
+]
 protobuf = [
-    {file = "protobuf-3.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1cb2ed66aac593adbf6dca4f07cd7ee7e2958b17bbc85b2cc8bc564ebeb258ec"},
-    {file = "protobuf-3.19.3-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:898bda9cd37ec0c781b598891e86435de80c3bfa53eb483a9dac5a11ec93e942"},
-    {file = "protobuf-3.19.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ad761ef3be34c8bdc7285bec4b40372a8dad9e70cfbdc1793cd3cf4c1a4ce74"},
-    {file = "protobuf-3.19.3-cp310-cp310-win32.whl", hash = "sha256:2cddcbcc222f3144765ccccdb35d3621dc1544da57a9aca7e1944c1a4fe3db11"},
-    {file = "protobuf-3.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:6202df8ee8457cb00810c6e76ced480f22a1e4e02c899a14e7b6e6e1de09f938"},
-    {file = "protobuf-3.19.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:397d82f1c58b76445469c8c06b8dee1ff67b3053639d054f52599a458fac9bc6"},
-    {file = "protobuf-3.19.3-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e54b8650e849ee8e95e481024bff92cf98f5ec61c7650cb838d928a140adcb63"},
-    {file = "protobuf-3.19.3-cp36-cp36m-win32.whl", hash = "sha256:3bf3a07d17ba3511fe5fa916afb7351f482ab5dbab5afe71a7a384274a2cd550"},
-    {file = "protobuf-3.19.3-cp36-cp36m-win_amd64.whl", hash = "sha256:afa8122de8064fd577f49ae9eef433561c8ace97a0a7b969d56e8b1d39b5d177"},
-    {file = "protobuf-3.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18c40a1b8721026a85187640f1786d52407dc9c1ba8ec38accb57a46e84015f6"},
-    {file = "protobuf-3.19.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:af7238849fa79285d448a24db686517570099739527a03c9c2971cce99cc5ae2"},
-    {file = "protobuf-3.19.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e765e6dfbbb02c55e4d6d1145743401a84fc0b508f5a81b2c5a738cf86353139"},
-    {file = "protobuf-3.19.3-cp37-cp37m-win32.whl", hash = "sha256:c781402ed5396ab56358d7b866d78c03a77cbc26ba0598d8bb0ac32084b1a257"},
-    {file = "protobuf-3.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:544fe9705189b249380fae07952d220c97f5c6c9372a6f936cc83a79601dcb70"},
-    {file = "protobuf-3.19.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:84bf3aa3efb00dbe1c7ed55da0f20800b0662541e582d7e62b3e1464d61ed365"},
-    {file = "protobuf-3.19.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3f80a3491eaca767cdd86cb8660dc778f634b44abdb0dffc9b2a8e8d0cd617d0"},
-    {file = "protobuf-3.19.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9401d96552befcc7311f5ef8f0fa7dba0ef5fd805466b158b141606cd0ab6a8"},
-    {file = "protobuf-3.19.3-cp38-cp38-win32.whl", hash = "sha256:ef02d112c025e83db5d1188a847e358beab3e4bbfbbaf10eaf69e67359af51b2"},
-    {file = "protobuf-3.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:1291a0a7db7d792745c99d4657b4c5c4942695c8b1ac1bfb993a34035ec123f7"},
-    {file = "protobuf-3.19.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:49677e5e9c7ea1245a90c2e8a00d304598f22ea3aa0628f0e0a530a9e70665fa"},
-    {file = "protobuf-3.19.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:df2ba379ee42427e8fcc6a0a76843bff6efb34ef5266b17f95043939b5e25b69"},
-    {file = "protobuf-3.19.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2acd7ca329be544d1a603d5f13a4e34a3791c90d651ebaf130ba2e43ae5397c6"},
-    {file = "protobuf-3.19.3-cp39-cp39-win32.whl", hash = "sha256:b53519b2ebec70cfe24b4ddda21e9843f0918d7c3627a785393fb35d402ab8ad"},
-    {file = "protobuf-3.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:8ceaf5fdb72c8e1fcb7be9f2b3b07482ce058a3548180c0bdd5c7e4ac5e14165"},
-    {file = "protobuf-3.19.3-py2.py3-none-any.whl", hash = "sha256:f6d4b5b7595a57e69eb7314c67bef4a3c745b4caf91accaf72913d8e0635111b"},
-    {file = "protobuf-3.19.3.tar.gz", hash = "sha256:d975a6314fbf5c524d4981e24294739216b5fb81ef3c14b86fb4b045d6690907"},
+    {file = "protobuf-3.19.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f51d5a9f137f7a2cec2d326a74b6e3fc79d635d69ffe1b036d39fc7d75430d37"},
+    {file = "protobuf-3.19.4-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:09297b7972da685ce269ec52af761743714996b4381c085205914c41fcab59fb"},
+    {file = "protobuf-3.19.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072fbc78d705d3edc7ccac58a62c4c8e0cec856987da7df8aca86e647be4e35c"},
+    {file = "protobuf-3.19.4-cp310-cp310-win32.whl", hash = "sha256:7bb03bc2873a2842e5ebb4801f5c7ff1bfbdf426f85d0172f7644fcda0671ae0"},
+    {file = "protobuf-3.19.4-cp310-cp310-win_amd64.whl", hash = "sha256:f358aa33e03b7a84e0d91270a4d4d8f5df6921abe99a377828839e8ed0c04e07"},
+    {file = "protobuf-3.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1c91ef4110fdd2c590effb5dca8fdbdcb3bf563eece99287019c4204f53d81a4"},
+    {file = "protobuf-3.19.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c438268eebb8cf039552897d78f402d734a404f1360592fef55297285f7f953f"},
+    {file = "protobuf-3.19.4-cp36-cp36m-win32.whl", hash = "sha256:835a9c949dc193953c319603b2961c5c8f4327957fe23d914ca80d982665e8ee"},
+    {file = "protobuf-3.19.4-cp36-cp36m-win_amd64.whl", hash = "sha256:4276cdec4447bd5015453e41bdc0c0c1234eda08420b7c9a18b8d647add51e4b"},
+    {file = "protobuf-3.19.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6cbc312be5e71869d9d5ea25147cdf652a6781cf4d906497ca7690b7b9b5df13"},
+    {file = "protobuf-3.19.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:54a1473077f3b616779ce31f477351a45b4fef8c9fd7892d6d87e287a38df368"},
+    {file = "protobuf-3.19.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:435bb78b37fc386f9275a7035fe4fb1364484e38980d0dd91bc834a02c5ec909"},
+    {file = "protobuf-3.19.4-cp37-cp37m-win32.whl", hash = "sha256:16f519de1313f1b7139ad70772e7db515b1420d208cb16c6d7858ea989fc64a9"},
+    {file = "protobuf-3.19.4-cp37-cp37m-win_amd64.whl", hash = "sha256:cdc076c03381f5c1d9bb1abdcc5503d9ca8b53cf0a9d31a9f6754ec9e6c8af0f"},
+    {file = "protobuf-3.19.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:69da7d39e39942bd52848438462674c463e23963a1fdaa84d88df7fbd7e749b2"},
+    {file = "protobuf-3.19.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:48ed3877fa43e22bcacc852ca76d4775741f9709dd9575881a373bd3e85e54b2"},
+    {file = "protobuf-3.19.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd95d1dfb9c4f4563e6093a9aa19d9c186bf98fa54da5252531cc0d3a07977e7"},
+    {file = "protobuf-3.19.4-cp38-cp38-win32.whl", hash = "sha256:b38057450a0c566cbd04890a40edf916db890f2818e8682221611d78dc32ae26"},
+    {file = "protobuf-3.19.4-cp38-cp38-win_amd64.whl", hash = "sha256:7ca7da9c339ca8890d66958f5462beabd611eca6c958691a8fe6eccbd1eb0c6e"},
+    {file = "protobuf-3.19.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:36cecbabbda242915529b8ff364f2263cd4de7c46bbe361418b5ed859677ba58"},
+    {file = "protobuf-3.19.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c1068287025f8ea025103e37d62ffd63fec8e9e636246b89c341aeda8a67c934"},
+    {file = "protobuf-3.19.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96bd766831596d6014ca88d86dc8fe0fb2e428c0b02432fd9db3943202bf8c5e"},
+    {file = "protobuf-3.19.4-cp39-cp39-win32.whl", hash = "sha256:84123274d982b9e248a143dadd1b9815049f4477dc783bf84efe6250eb4b836a"},
+    {file = "protobuf-3.19.4-cp39-cp39-win_amd64.whl", hash = "sha256:3112b58aac3bac9c8be2b60a9daf6b558ca3f7681c130dcdd788ade7c9ffbdca"},
+    {file = "protobuf-3.19.4-py2.py3-none-any.whl", hash = "sha256:8961c3a78ebfcd000920c9060a262f082f29838682b1f7201889300c1fbe0616"},
+    {file = "protobuf-3.19.4.tar.gz", hash = "sha256:9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a"},
 ]
 psutil = [
     {file = "psutil-5.9.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b"},
@@ -1575,6 +2186,20 @@ pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
     {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
+pywin32 = [
+    {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
+    {file = "pywin32-227-cp27-cp27m-win_amd64.whl", hash = "sha256:4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116"},
+    {file = "pywin32-227-cp35-cp35m-win32.whl", hash = "sha256:f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"},
+    {file = "pywin32-227-cp35-cp35m-win_amd64.whl", hash = "sha256:a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4"},
+    {file = "pywin32-227-cp36-cp36m-win32.whl", hash = "sha256:300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be"},
+    {file = "pywin32-227-cp36-cp36m-win_amd64.whl", hash = "sha256:9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2"},
+    {file = "pywin32-227-cp37-cp37m-win32.whl", hash = "sha256:47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507"},
+    {file = "pywin32-227-cp37-cp37m-win_amd64.whl", hash = "sha256:31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511"},
+    {file = "pywin32-227-cp38-cp38-win32.whl", hash = "sha256:7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc"},
+    {file = "pywin32-227-cp38-cp38-win_amd64.whl", hash = "sha256:7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e"},
+    {file = "pywin32-227-cp39-cp39-win32.whl", hash = "sha256:c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295"},
+    {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
+]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
     {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
@@ -1605,6 +2230,14 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
+querystring-parser = [
+    {file = "querystring_parser-1.2.4-py2.py3-none-any.whl", hash = "sha256:d2fa90765eaf0de96c8b087872991a10238e89ba015ae59fedfed6bd61c242a0"},
+    {file = "querystring_parser-1.2.4.tar.gz", hash = "sha256:644fce1cffe0530453b43a83a38094dbe422ccba8c9b2f2a1c00280e14ca8a62"},
+]
+requests = [
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 scipy = [
     {file = "scipy-1.7.3-1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:c9e04d7e9b03a8a6ac2045f7c5ef741be86727d8f49c45db45f244bdd2bcff17"},
@@ -1649,6 +2282,56 @@ six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
+smmap = [
+    {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
+    {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
+]
+sqlalchemy = [
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c3abc34fed19fdeaead0ced8cf56dd121f08198008c033596aa6aae7cc58f59f"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8d0949b11681380b4a50ac3cd075e4816afe9fa4a8c8ae006c1ca26f0fa40ad8"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-win32.whl", hash = "sha256:f3b7ec97e68b68cb1f9ddb82eda17b418f19a034fa8380a0ac04e8fe01532875"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-win_amd64.whl", hash = "sha256:81f2dd355b57770fdf292b54f3e0a9823ec27a543f947fa2eb4ec0df44f35f0d"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4ad31cec8b49fd718470328ad9711f4dc703507d434fd45461096da0a7135ee0"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:05fa14f279d43df68964ad066f653193187909950aa0163320b728edfc400167"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dccff41478050e823271642837b904d5f9bda3f5cf7d371ce163f00a694118d6"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57205844f246bab9b666a32f59b046add8995c665d9ecb2b7b837b087df90639"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea8210090a816d48a4291a47462bac750e3bc5c2442e6d64f7b8137a7c3f9ac5"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-win32.whl", hash = "sha256:2e216c13ecc7fcdcbb86bb3225425b3ed338e43a8810c7089ddb472676124b9b"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-win_amd64.whl", hash = "sha256:e3a86b59b6227ef72ffc10d4b23f0fe994bef64d4667eab4fb8cd43de4223bec"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:2fd4d3ca64c41dae31228b80556ab55b6489275fb204827f6560b65f95692cf3"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f22c040d196f841168b1456e77c30a18a3dc16b336ddbc5a24ce01ab4e95ae0"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c0c7171aa5a57e522a04a31b84798b6c926234cb559c0939840c3235cf068813"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d046a9aeba9bc53e88a41e58beb72b6205abb9a20f6c136161adf9128e589db5"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-win32.whl", hash = "sha256:d86132922531f0dc5a4f424c7580a472a924dd737602638e704841c9cb24aea2"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-win_amd64.whl", hash = "sha256:ca68c52e3cae491ace2bf39b35fef4ce26c192fd70b4cd90f040d419f70893b5"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:cf2cd387409b12d0a8b801610d6336ee7d24043b6dd965950eaec09b73e7262f"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb4b15fb1f0aafa65cbdc62d3c2078bea1ceecbfccc9a1f23a2113c9ac1191fa"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c317ddd7c586af350a6aef22b891e84b16bff1a27886ed5b30f15c1ed59caeaa"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c7ed6c69debaf6198fadb1c16ae1253a29a7670bbf0646f92582eb465a0b999"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-win32.whl", hash = "sha256:6a01ec49ca54ce03bc14e10de55dfc64187a2194b3b0e5ac0fdbe9b24767e79e"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-win_amd64.whl", hash = "sha256:330eb45395874cc7787214fdd4489e2afb931bc49e0a7a8f9cd56d6e9c5b1639"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:5e9c7b3567edbc2183607f7d9f3e7e89355b8f8984eec4d2cd1e1513c8f7b43f"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de85c26a5a1c72e695ab0454e92f60213b4459b8d7c502e0be7a6369690eeb1a"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:975f5c0793892c634c4920057da0de3a48bbbbd0a5c86f5fcf2f2fedf41b76da"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5c20c8415173b119762b6110af64448adccd4d11f273fb9f718a9865b88a99c"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-win32.whl", hash = "sha256:b35dca159c1c9fa8a5f9005e42133eed82705bf8e243da371a5e5826440e65ca"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-win_amd64.whl", hash = "sha256:b7b20c88873675903d6438d8b33fba027997193e274b9367421e610d9da76c08"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:85e4c244e1de056d48dae466e9baf9437980c19fcde493e0db1a0a986e6d75b4"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e79e73d5ee24196d3057340e356e6254af4d10e1fc22d3207ea8342fc5ffb977"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:15a03261aa1e68f208e71ae3cd845b00063d242cbf8c87348a0c2c0fc6e1f2ac"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ddc5e5ccc0160e7ad190e5c61eb57560f38559e22586955f205e537cda26034"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-win32.whl", hash = "sha256:289465162b1fa1e7a982f8abe59d26a8331211cad4942e8031d2b7db1f75e649"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-win_amd64.whl", hash = "sha256:9e4fb2895b83993831ba2401b6404de953fdbfa9d7d4fa6a4756294a83bbc94f"},
+    {file = "SQLAlchemy-1.4.31.tar.gz", hash = "sha256:582b59d1e5780a447aada22b461e50b404a9dc05768da1d87368ad8190468418"},
+]
+sqlparse = [
+    {file = "sqlparse-0.4.2-py3-none-any.whl", hash = "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"},
+    {file = "sqlparse-0.4.2.tar.gz", hash = "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae"},
+]
+tabulate = [
+    {file = "tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4"},
+    {file = "tabulate-0.8.9.tar.gz", hash = "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"},
+]
 taskipy = [
     {file = "taskipy-1.9.0-py3-none-any.whl", hash = "sha256:02bd2c51c7356ed3f7f8853210ada1cd2ab273e68359ee865021c3057eec6615"},
     {file = "taskipy-1.9.0.tar.gz", hash = "sha256:449c160b557cdb1d9c17097a5ea4aa0cd5223723ddbaaa5d5032dd16274fb8f0"},
@@ -1668,6 +2351,14 @@ tqdm = [
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+]
+waitress = [
+    {file = "waitress-2.0.0-py3-none-any.whl", hash = "sha256:29af5a53e9fb4e158f525367678b50053808ca6c21ba585754c77d790008c746"},
+    {file = "waitress-2.0.0.tar.gz", hash = "sha256:69e1f242c7f80273490d3403c3976f3ac3b26e289856936d1f620ed48f321897"},
 ]
 watchdog = [
     {file = "watchdog-2.1.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9693f35162dc6208d10b10ddf0458cc09ad70c30ba689d9206e02cd836ce28a3"},
@@ -1693,6 +2384,14 @@ watchdog = [
     {file = "watchdog-2.1.6-py3-none-win_amd64.whl", hash = "sha256:bd9ba4f332cf57b2c1f698be0728c020399ef3040577cde2939f2e045b39c1e5"},
     {file = "watchdog-2.1.6-py3-none-win_ia64.whl", hash = "sha256:a0f1c7edf116a12f7245be06120b1852275f9506a7d90227648b250755a03923"},
     {file = "watchdog-2.1.6.tar.gz", hash = "sha256:a36e75df6c767cbf46f61a91c70b3ba71811dfa0aca4a324d9407a06a8b7a2e7"},
+]
+websocket-client = [
+    {file = "websocket-client-1.2.3.tar.gz", hash = "sha256:1315816c0acc508997eb3ae03b9d3ff619c9d12d544c9a9b553704b1cc4f6af5"},
+    {file = "websocket_client-1.2.3-py3-none-any.whl", hash = "sha256:2eed4cc58e4d65613ed6114af2f380f7910ff416fc8c46947f6e76b6815f56c0"},
+]
+werkzeug = [
+    {file = "Werkzeug-2.0.2-py3-none-any.whl", hash = "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f"},
+    {file = "Werkzeug-2.0.2.tar.gz", hash = "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"},
 ]
 zipp = [
     {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},

--- a/environment/pyproject.toml
+++ b/environment/pyproject.toml
@@ -9,16 +9,17 @@ license = "Apache-2.0"
 python = ">=3.7,<3.10"
 atari-py = "0.2.9"
 cogment = {extras = ["generate"], version = "^2.0.2"}
+cogment-verse = {path = "../base_python", develop = true}
+filelock = "^3.4.0"
 gym = {version = "0.18.0", extras = ["atari", "box2d"]}
 gym-tetris = "^3.0.2"
 minatar = {git = "https://github.com/kenjyoung/MinAtar.git", rev = "f1387b4123ea5a0203c81b2d3ad9572a8cc578cf"}
 PettingZoo = "^1.11.1"
-pyglet = "^1.4"
+procgen = "^0.10.4"
 pygame = "^2.0.2"
+pyglet = "^1.4"
 python-dotenv = "^0.19.1"
 PyYAML = "^5.4.1"
-filelock = "^3.4.0"
-procgen = "^0.10.4"
 
 [tool.poetry.dev-dependencies]
 taskipy = "^1.9.0"

--- a/environment/tests/conftest.py
+++ b/environment/tests/conftest.py
@@ -14,7 +14,7 @@
 
 import pytest
 from cogment_verse_environment.environment_adapter import EnvironmentAdapter
-from tests.mock_environment_session import MockEnvironmentSession
+from mock_environment_session import MockEnvironmentSession
 
 # pylint: disable=protected-access
 

--- a/environment/tests/test_atari.py
+++ b/environment/tests/test_atari.py
@@ -15,7 +15,7 @@
 import pytest
 from cogment_verse_environment.utils.serialization_helpers import deserialize_img, deserialize_np_array
 from data_pb2 import AgentAction, EnvironmentConfig
-from tests.mock_environment_session import ActorInfo
+from mock_environment_session import ActorInfo
 
 # pylint doesn't like test fixtures
 # pylint: disable=redefined-outer-name
@@ -27,7 +27,7 @@ async def test_observation(create_mock_environment_session, framestack):
     tetris_session = create_mock_environment_session(
         impl_name="atari/TetrisALE",
         trial_id="test_atari",
-        environment_config=EnvironmentConfig(player_count=1, framestack=framestack, flatten=True),
+        environment_config=EnvironmentConfig(framestack=framestack, flatten=True),
         actor_infos=[ActorInfo("player_1", "player")],
     )
 
@@ -51,7 +51,7 @@ async def tetris_session(create_mock_environment_session):
     session = create_mock_environment_session(
         impl_name="atari/TetrisALE",
         trial_id="test_atari",
-        environment_config=EnvironmentConfig(player_count=1, framestack=4, flatten=True),
+        environment_config=EnvironmentConfig(framestack=4, flatten=True),
         actor_infos=[ActorInfo("player_1", "player")],
     )
 

--- a/environment/tests/test_minatarenv.py
+++ b/environment/tests/test_minatarenv.py
@@ -15,7 +15,7 @@
 import pytest
 from cogment_verse_environment.utils.serialization_helpers import deserialize_img, deserialize_np_array
 from data_pb2 import EnvironmentConfig
-from tests.mock_environment_session import ActorInfo
+from mock_environment_session import ActorInfo
 
 # pylint: disable=redefined-outer-name
 
@@ -26,7 +26,7 @@ async def breakout_session(create_mock_environment_session):
     session = create_mock_environment_session(
         impl_name="minatar/breakout",
         trial_id="test_minatar",
-        environment_config=EnvironmentConfig(player_count=1, framestack=4, flatten=True),
+        environment_config=EnvironmentConfig(framestack=4, flatten=True),
         actor_infos=[ActorInfo("player_1", "player")],
     )
 

--- a/environment/tests/test_pettingzoo.py
+++ b/environment/tests/test_pettingzoo.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 from cogment_verse_environment.utils.serialization_helpers import deserialize_img, deserialize_np_array
 from data_pb2 import AgentAction, EnvironmentConfig
-from tests.mock_environment_session import ActorInfo
+from mock_environment_session import ActorInfo
 
 # pylint doesn't like test fixtures
 # pylint: disable=redefined-outer-name
@@ -28,7 +28,7 @@ async def connect_four_session(create_mock_environment_session):
     session = create_mock_environment_session(
         impl_name="pettingzoo/connect_four_v3",
         trial_id="test_pettingzoo",
-        environment_config=EnvironmentConfig(player_count=2, framestack=1, flatten=True),
+        environment_config=EnvironmentConfig(framestack=1, flatten=True),
         actor_infos=[ActorInfo("player_1", "player"), ActorInfo("player_2", "player")],
     )
 

--- a/environment/tests/test_procgen.py
+++ b/environment/tests/test_procgen.py
@@ -17,7 +17,7 @@ import pytest
 from cogment_verse_environment.procgen_env import ENV_NAMES, ProcGenEnv
 from cogment_verse_environment.utils.serialization_helpers import deserialize_img, deserialize_np_array
 from data_pb2 import AgentAction, EnvironmentConfig
-from tests.mock_environment_session import ActorInfo
+from mock_environment_session import ActorInfo
 
 # pylint doesn't like test fixtures
 # pylint: disable=redefined-outer-name
@@ -31,7 +31,7 @@ async def test_observation(create_mock_environment_session, env_name, framestack
     session = create_mock_environment_session(
         impl_name=f"procgen/{env_name}",
         trial_id="test_procgen",
-        environment_config=EnvironmentConfig(player_count=1, framestack=framestack, flatten=flatten),
+        environment_config=EnvironmentConfig(framestack=framestack, flatten=flatten),
         actor_infos=[ActorInfo("player_1", "player")],
     )
 
@@ -59,7 +59,7 @@ async def test_step(create_mock_environment_session, env_name):
     session = create_mock_environment_session(
         impl_name=f"procgen/{env_name}",
         trial_id="test_procgen",
-        environment_config=EnvironmentConfig(player_count=1, framestack=4, flatten=True),
+        environment_config=EnvironmentConfig(framestack=4, flatten=True),
         actor_infos=[ActorInfo("player_1", "player")],
     )
     tick_0_events = await session.receive_events()

--- a/run_params.yaml
+++ b/run_params.yaml
@@ -74,18 +74,18 @@ play:
     observer: true
     trial_count: 10
     environment:
-      specs: *atari_pitfall_specs
+      specs: *cartpole_specs
     actors:
     # Configure the players (only the first ones are used, up to the number of required players)
     - name: agent_1
       actor_class: agent
-      implementation: random
+      # implementation: random
       # To use an already trained agent use the following.
       # Make sure the model is compatible with the implementation and the environment
-      #implementation: dqn
-      #agent_config:
-      #  model_id: dreamy_lamarr_model
-      #  model_version: 5
+      implementation: rainbowtorch
+      agent_config:
+       model_id: compassionate_aryabhata_model
+       model_version: -1
     - name: agent_2
       actor_class: agent
       implementation: random

--- a/run_params.yaml
+++ b/run_params.yaml
@@ -2,54 +2,67 @@
 environment_specs:
   cartpole_specs: &cartpole_specs
     implementation: gym/CartPole-v0
+    num_players: 1
     num_input: 4
     num_action: 2
   pendulum_specs: &pendulum_specs
     implementation: gym/Pendulum-v0
+    num_players: 1
     num_input: 3
     num_action: 1
   mountain_car_specs: &mountain_car_specs
     implementation: gym/MountainCar-v0
+    num_players: 1
     num_input: 2
     num_action: 3
   lander_specs: &lander_specs
     implementation: gym/LunarLander-v2
+    num_players: 1
     num_input: 8
     num_action: 4
   lander_continuous_specs: &lander_continuous_specs
     implementation: gym/LunarLanderContinuous-v2
+    num_players: 1
     num_input: 8
     num_action: 2
   bipedal_walker_specs: &bipedal_walker_specs
     implementation: gym/BipedalWalker-v3
+    num_players: 1
     num_input: 24
     num_action: 4
   minatar_breakout_specs: &minatar_breakout_specs
     implementation: minatar/breakout
+    num_players: 1
     num_input: 500
     num_action: 6
   atari_pitfall_specs: &atari_pitfall_specs
     implementation: atari/Pitfall
+    num_players: 1
     num_input: 7056
     num_action: 18
   atari_breakout_specs: &atari_breakout_specs
     implementation: atari/Breakout
+    num_players: 1
     num_input: 7056
     num_action: 4
   tetris_specs: &tetris_specs
     implementation: tetris/TetrisA-v0
+    num_players: 1
     num_input: 7056
     num_action: 12
   procgen_bigfish_specs: &procgen_bigfish_specs
     implementation: procgen/bigfish
+    num_players: 1
     num_input: 7056
     num_action: 15
   pettingzoo_connect_four_specs: &pettingzoo_connect_four_specs
     implementation: pettingzoo/connect_four_v3
+    num_players: 2
     num_input: 84
     num_action: 7
   pettingzoo_backgammon_specs: &pettingzoo_backgammon_specs
     implementation: pettingzoo/backgammon_v3
+    num_players: 2
     num_input: 198
     num_action: 1353
 
@@ -62,8 +75,6 @@ play:
     trial_count: 10
     environment:
       specs: *atari_pitfall_specs
-      config:
-        player_count: 1
     actors:
     # Configure the players (only the first ones are used, up to the number of required players)
     - name: agent_1
@@ -86,7 +97,6 @@ cartpole_rainbow: &default_params
     environment:
       specs: *cartpole_specs
       config: &default_env_config
-        player_count: 1
         render_width: 256
         flatten: True
         framestack: 1
@@ -285,9 +295,7 @@ connect_four_rainbow:
     <<: *default_config
     environment:
       specs: *pettingzoo_connect_four_specs
-      config:
-        <<: *default_env_config
-        player_count: 2
+      config: *default_env_config
     agent_implementation: rainbowtorch
     demonstration_count: 0 #100
     total_trial_count: 10000
@@ -307,9 +315,7 @@ backgammon_rainbow:
         implementation: pet/backgammon_v3
         num_input: 198
         num_action: 1353
-      config:
-        <<: *default_env_config
-        player_count: 2
+      config: *default_env_config
     demonstration_count: 0 #100
     total_trial_count: 10
     model_publication_interval: 100
@@ -576,9 +582,7 @@ benchmark_connect_four:
     <<: *default_config
     environment:
       specs: *pettingzoo_connect_four_specs
-      config:
-        <<: *default_env_config
-        player_count: 2
+      config: *default_env_config
     agent_implementation: rainbowtorch
     environment_implementation:
     demonstration_count: 0 #100

--- a/run_params.yaml
+++ b/run_params.yaml
@@ -3,7 +3,16 @@ cartpole_rainbow: &default_params
   implementation: "cogment_verse_run_impl"
   config: &default_config
     class_name: data_pb2.RunConfig
-    player_count: 1
+    environment:
+      specs:
+        implementation: gym/CartPole-v0
+        num_input: 4
+        num_action: 2
+      config: &default_env_config
+        player_count: 1
+        render_width: 256
+        flatten: True
+        framestack: 1
     epsilon_min: 0.1
     epsilon_steps: 100000
     target_net_update_schedule: 1000
@@ -13,31 +22,22 @@ cartpole_rainbow: &default_params
     total_trial_count: 10000
     model_publication_interval: 1000
     model_archive_interval_multiplier: 4 # Archive every fourth published model
-    render_width: 256
     batch_size: 256
     min_replay_buffer_size: 1000
     max_parallel_trials: 4
     model_kwargs: {}
     max_replay_buffer_size: 100000
-    flatten: True
     aggregate_by_actor: False
-    framestack: 1
     replay_buffer_config:
       observation_dtype: float32
       action_dtype: int8
-    num_input: 4
-    num_action: 2
     agent_implementation: rainbowtorch
-    environment_implementation: gym/CartPole-v0
 
 cartpole_dqn:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 4
-    num_action: 2
     agent_implementation: dqn
-    environment_implementation: gym/CartPole-v0
 
 cartpole_REINFORCE:
   implementation: "reinforce_training"
@@ -53,10 +53,13 @@ pendulum_td3:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 3
-    num_action: 1
+    environment:
+      specs:
+        implementation: gym/Pendulum-v0
+        num_input: 3
+        num_action: 1
+      config: *default_env_config
     agent_implementation: td3
-    environment_implementation: gym/Pendulum-v0
     epsilon_min: 0.0
     epsilon_steps: 1
     target_net_update_schedule: 2
@@ -76,35 +79,45 @@ minatar_breakout_rainbow:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 400
-    num_action: 6
+    environment:
+      specs:
+        implementation: min/breakout
+        num_input: 500
+        num_action: 6
+      config: *default_env_config
     agent_implementation: rainbowtorch
-    environment_implementation: min/breakout
 
 atari_pitfall_rainbow:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 7056
-    num_action: 18
+    environment:
+      specs:
+        implementation: ata/Pitfall
+        num_input: 7056
+        num_action: 18
+      config: *default_env_config
     agent_implementation: rainbowtorch
-    environment_implementation: ata/Pitfall
 
 atari_breakout_cnn:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 7056
-    num_action: 4
+    environment:
+      specs:
+        implementation: ata/Breakout
+        num_input: 7056
+        num_action: 4
+      config:
+        <<: *default_env_config
+        flatten: false
+        framestack: 4
     agent_implementation: atari_cnn
-    environment_implementation: ata/Breakout
     demonstration_count: 0
     total_trial_count: 10000
     model_publication_interval: 1000
     model_archive_interval_multiplier: 100
     max_parallel_trials: 2
-    render_width: 256
-    flatten: false
     batch_size: 1024
     min_replay_buffer_size: 10000
     max_replay_buffer_size: 350000
@@ -112,7 +125,6 @@ atari_breakout_cnn:
     epsilon_steps: 100000
     learning_rate: 1.0e-4
     lr_warmup_steps: 10000
-    framestack: 4
     model_kwargs:
       target_net_soft_update: False
     replay_buffer_config:
@@ -123,41 +135,54 @@ minatar_breakout_demo:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 400
-    num_action: 6
+    environment:
+      specs:
+        implementation: min/breakout
+        num_input: 400
+        num_action: 6
+      config: *default_env_config
     agent_implementation: rainbowtorch
-    environment_implementation: min/breakout
-    demonstration_count: 0
 
 atari_breakout_demo:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 7056
-    num_action: 4
+    environment:
+      specs:
+        implementation: ata/Breakout
+        num_input: 7056
+        num_action: 4
+      config:
+        <<: *default_env_config
+        framestack: 4
     agent_implementation: rainbowtorch
-    environment_implementation: ata/Breakout
-    demonstration_count: 0
-    framestack: 4
 
 atari_pitfall_demo:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 7056
-    num_action: 18
+    environment:
+      specs:
+        implementation: ata/Pitfall
+        num_input: 7056
+        num_action: 18
+      config: *default_env_config
     agent_implementation: rainbowtorch
-    environment_implementation: ata/Pitfall
     demonstration_count: 10
 
 lander_rainbow_demo: &lander_rainbow_demo
   <<: *default_params
   config: &lander_rainbow_config
     <<: *default_config
-    num_input: 8
-    num_action: 4
+    environment:
+      specs:
+        implementation: gym/LunarLander-v2
+        num_input: 8
+        num_action: 4
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: rainbowtorch
-    environment_implementation: gym/LunarLander-v2
     demonstration_count: 20000 #100
     total_trial_count: 20000
     epsilon_min: 0.1
@@ -166,7 +191,6 @@ lander_rainbow_demo: &lander_rainbow_demo
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 200
-    render_width: 1000
     batch_size: 32
     min_replay_buffer_size: 32
 
@@ -183,10 +207,16 @@ tetris_rainbow_demo:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 7056
-    num_action: 12
+    environment:
+      specs:
+        implementation: tet/TetrisA-v0
+        num_input: 7056
+        num_action: 12
+      config:
+        <<: *default_env_config
+        render_width: 1000
+        flatten: False
     agent_implementation: atari_cnn
-    environment_implementation: tet/TetrisA-v0
     demonstration_count: 1000 #100
     total_trial_count: 10000
     epsilon_min: 0.1
@@ -195,21 +225,23 @@ tetris_rainbow_demo:
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 2000
-    render_width: 1000
     batch_size: 32
     min_replay_buffer_size: 32
     max_replay_buffer_size: 10000
-    flatten: False
 
 connect_four_rainbow:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 84
-    num_action: 7
-    player_count: 2
+    environment:
+      specs:
+        implementation: pet/connect_four_v3
+        num_input: 84
+        num_action: 7
+      config:
+        <<: *default_env_config
+        player_count: 2
     agent_implementation: rainbowtorch
-    environment_implementation: pet/connect_four_v3
     demonstration_count: 0 #100
     total_trial_count: 10000
     epsilon_steps: 5000
@@ -223,11 +255,14 @@ backgammon_rainbow:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 198
-    num_action: 1353
-    player_count: 2
-    agent_implementation: rainbowtorch
-    environment_implementation: pet/backgammon_v3
+    environment:
+      specs:
+        implementation: pet/backgammon_v3
+        num_input: 198
+        num_action: 1353
+      config:
+        <<: *default_env_config
+        player_count: 2
     demonstration_count: 0 #100
     total_trial_count: 10
     model_publication_interval: 100
@@ -236,10 +271,15 @@ benchmark_lander:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 8
-    num_action: 4
+    environment:
+      specs:
+        implementation: gym/LunarLander-v2
+        num_input: 8
+        num_action: 4
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: rainbowtorch
-    environment_implementation: gym/LunarLander-v2
     demonstration_count: 0
     total_trial_count: 250
     epsilon_min: 0.10
@@ -248,7 +288,6 @@ benchmark_lander:
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 250
-    render_width: 1000
     batch_size: 32
     min_replay_buffer_size: 32
     model_kwargs:
@@ -259,10 +298,15 @@ benchmark_lander_hill:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 8
-    num_action: 4
+    environment:
+      specs:
+        implementation: gym/LunarLander-v2
+        num_input: 8
+        num_action: 4
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: rainbowtorch
-    environment_implementation: gym/LunarLander-v2
     demonstration_count: 1000
     total_trial_count: 1000
     epsilon_min: 0.1
@@ -271,7 +315,6 @@ benchmark_lander_hill:
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 250
-    render_width: 1000
     batch_size: 256
     min_replay_buffer_size: 256
     model_kwargs:
@@ -282,10 +325,15 @@ lander_continuous_td3:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 8
-    num_action: 2
+    environment:
+      specs:
+        implementation: gym/LunarLanderContinuous-v2
+        num_input: 8
+        num_action: 2
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: td3
-    environment_implementation: gym/LunarLanderContinuous-v2
     demonstration_count: 0
     total_trial_count: 1000
     epsilon_min: 0.0
@@ -312,10 +360,15 @@ lander_continuous_ddpg:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 8
-    num_action: 2
+    environment:
+      specs:
+        implementation: gym/LunarLanderContinuous-v2
+        num_input: 8
+        num_action: 2
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: ddpg
-    environment_implementation: gym/LunarLanderContinuous-v2
     demonstration_count: 0
     total_trial_count: 1000
     epsilon_min: 0.1
@@ -324,7 +377,6 @@ lander_continuous_ddpg:
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 250
-    render_width: 1000
     batch_size: 64
     min_replay_buffer_size: 64
     max_replay_buffer_size: 100000
@@ -342,10 +394,15 @@ walker_td3:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 8
-    num_action: 2
+    environment:
+      specs:
+        implementation: gym/BipedalWalker-v3
+        num_input: 8
+        num_action: 2
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: td3
-    environment_implementation: gym/BipedalWalker-v3
     demonstration_count: 0
     total_trial_count: 1000
     epsilon_min: 0.0
@@ -354,7 +411,6 @@ walker_td3:
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 250
-    render_width: 1000
     batch_size: 256
     min_replay_buffer_size: 256
     max_replay_buffer_size: 100000
@@ -372,10 +428,15 @@ walker_ddpg:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 24
-    num_action: 4
+    environment:
+      specs:
+        implementation: gym/BipedalWalker-v3
+        num_input: 24
+        num_action: 4
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: ddpg
-    environment_implementation: gym/BipedalWalker-v3
     demonstration_count: 0
     total_trial_count: 1000
     epsilon_min: 0.1
@@ -383,7 +444,6 @@ walker_ddpg:
     target_net_update_schedule: 2
     learning_rate: 1.0e-4
     model_publication_interval: 250
-    render_width: 1000
     batch_size: 64
     min_replay_buffer_size: 64
     max_replay_buffer_size: 100000
@@ -401,10 +461,15 @@ pendulum_td3:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 3
-    num_action: 1
+    environment:
+      specs:
+        implementation: gym/Pendulum-v0
+        num_input: 3
+        num_action: 1
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: td3
-    environment_implementation: gym/Pendulum-v0
     demonstration_count: 0 #100
     total_trial_count: 250
     epsilon_min: 0.0
@@ -414,7 +479,6 @@ pendulum_td3:
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 1000
-    render_width: 1000
     batch_size: 64
     min_replay_buffer_size: 64
     replay_buffer_config:
@@ -430,10 +494,15 @@ pendulum_ddpg:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 3
-    num_action: 1
+    environment:
+      specs:
+        implementation: gym/Pendulum-v0
+        num_input: 3
+        num_action: 1
+      config:
+        <<: *default_env_config
+        render_width: 1000
     agent_implementation: ddpg
-    environment_implementation: gym/Pendulum-v0
     demonstration_count: 0 #100
     total_trial_count: 250
     epsilon_min: 0.0
@@ -443,7 +512,6 @@ pendulum_ddpg:
     learning_rate: 1.0e-4
     lr_warmup_steps: 100
     model_publication_interval: 1000
-    render_width: 1000
     batch_size: 64
     min_replay_buffer_size: 64
     max_replay_buffer_size: 10000
@@ -460,10 +528,13 @@ benchmark_breakout:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 400
-    num_action: 6
+    environment:
+      specs:
+        implementation: min/breakout
+        num_input: 400
+        num_action: 6
+      config: *default_env_config
     agent_implementation: rainbowtorch
-    environment_implementation: min/breakout
     demonstration_count: 0
     total_trial_count: 1000
     model_publication_interval: 100
@@ -477,11 +548,16 @@ benchmark_connect_four:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 84
-    num_action: 7
-    player_count: 2
+    environment:
+      specs:
+        implementation: pet/connect_four_v3
+        num_input: 84
+        num_action: 7
+      config:
+        <<: *default_env_config
+        player_count: 2
     agent_implementation: rainbowtorch
-    environment_implementation: pet/connect_four_v3
+    environment_implementation:
     demonstration_count: 0 #100
     total_trial_count: 10
     epsilon_steps: 5000
@@ -503,6 +579,7 @@ simple_a2c_cartpole: &default_simple_a2c_params
         num_input: 4
         num_action: 2
       config:
+        <<: *default_env_config
         seed: 12
     training:
       epoch_count: 100
@@ -524,17 +601,22 @@ procgen_bigfish:
   <<: *default_params
   config:
     <<: *default_config
-    num_input: 7056
-    num_action: 15
+    environment:
+      specs:
+        implementation: procgen/bigfish
+        num_input: 7056
+        num_action: 15
+      config:
+        <<: *default_env_config
+        render_width: 64
+        flatten: false
+        framestack: 4
     agent_implementation: atari_cnn
-    environment_implementation: procgen/bigfish
     demonstration_count: 100
     total_trial_count: 10000
     model_publication_interval: 1000
     model_archive_interval_multiplier: 10
     max_parallel_trials: 2
-    render_width: 64
-    flatten: false
     batch_size: 32
     min_replay_buffer_size: 10000
     max_replay_buffer_size: 350000
@@ -542,7 +624,6 @@ procgen_bigfish:
     epsilon_steps: 100000
     learning_rate: 1.0e-4
     lr_warmup_steps: 10000
-    framestack: 4
     model_kwargs:
       target_net_soft_update: False
       screensize: 64

--- a/run_params.yaml
+++ b/run_params.yaml
@@ -677,3 +677,27 @@ simple_bc_mountaincar:
       config:
         seed: 12
 
+play:
+  implementation: play
+  config:
+    class_name: data_pb2.PlayRunConfig
+    # Set to true to have the ability to observe the run in the web client
+    observer: true
+    trial_count: 10
+    environment:
+      specs:
+        implementation: gym/LunarLander-v2
+        num_input: 8
+        num_action: 4
+      config:
+        player_count: 1
+    actors:
+    - name: player_1
+      actor_class: agent
+      implementation: random
+      # To use an already trained agent use the following.
+      # Make sure the model is compatible with the implementation and the environment
+      #implementation: dqn
+      #agent_config:
+      #  model_id: dreamy_lamarr_model
+      #  model_version: 5

--- a/run_params.yaml
+++ b/run_params.yaml
@@ -498,12 +498,12 @@ simple_a2c_cartpole: &default_simple_a2c_params
   config: &default_simple_a2c_config
     class_name: data_pb2.SimpleA2CTrainingRunConfig
     environment:
-      implementation: gym/CartPole-v0
+      specs:
+        implementation: gym/CartPole-v0
+        num_input: 4
+        num_action: 2
       config:
         seed: 12
-    actor:
-      num_input: 4
-      num_action: 2
     training:
       epoch_count: 100
       epoch_trial_count: 15
@@ -556,12 +556,12 @@ simple_bc_lander: &simple_bc_experiment
   config: &simple_bc_config
     class_name: data_pb2.SimpleBCTrainingRunConfig
     environment:
-      implementation: gym/LunarLander-v2
+      specs:
+        implementation: gym/LunarLander-v2
+        num_input: 8
+        num_action: 4
       config:
         seed: 12
-    actor:
-      num_input: 8
-      num_action: 4
     training:
       trial_count: 1000
       max_parallel_trials: 1
@@ -576,12 +576,12 @@ simple_bc_cartpole:
   config:
     <<: *simple_bc_config
     environment:
-      implementation: gym/CartPole-v0
-      config:
-        seed: 12
-    actor:
+      specs:
+        implementation: gym/CartPole-v0
         num_input: 4
         num_action: 2
+      config:
+        seed: 12
 
 simple_bc_mountaincar:
   <<: *simple_bc_experiment
@@ -589,10 +589,10 @@ simple_bc_mountaincar:
   config:
     <<: *simple_bc_config
     environment:
-      implementation: gym/MountainCar-v0
-      config:
-        seed: 12
-    actor:
+      specs:
+        implementation: gym/MountainCar-v0
         num_input: 2
         num_action: 3
+      config:
+        seed: 12
 

--- a/run_params.yaml
+++ b/run_params.yaml
@@ -1,13 +1,90 @@
 
+environment_specs:
+  cartpole_specs: &cartpole_specs
+    implementation: gym/CartPole-v0
+    num_input: 4
+    num_action: 2
+  pendulum_specs: &pendulum_specs
+    implementation: gym/Pendulum-v0
+    num_input: 3
+    num_action: 1
+  mountain_car_specs: &mountain_car_specs
+    implementation: gym/MountainCar-v0
+    num_input: 2
+    num_action: 3
+  lander_specs: &lander_specs
+    implementation: gym/LunarLander-v2
+    num_input: 8
+    num_action: 4
+  lander_continuous_specs: &lander_continuous_specs
+    implementation: gym/LunarLanderContinuous-v2
+    num_input: 8
+    num_action: 2
+  bipedal_walker_specs: &bipedal_walker_specs
+    implementation: gym/BipedalWalker-v3
+    num_input: 24
+    num_action: 4
+  minatar_breakout_specs: &minatar_breakout_specs
+    implementation: minatar/breakout
+    num_input: 500
+    num_action: 6
+  atari_pitfall_specs: &atari_pitfall_specs
+    implementation: atari/Pitfall
+    num_input: 7056
+    num_action: 18
+  atari_breakout_specs: &atari_breakout_specs
+    implementation: atari/Breakout
+    num_input: 7056
+    num_action: 4
+  tetris_specs: &tetris_specs
+    implementation: tetris/TetrisA-v0
+    num_input: 7056
+    num_action: 12
+  procgen_bigfish_specs: &procgen_bigfish_specs
+    implementation: procgen/bigfish
+    num_input: 7056
+    num_action: 15
+  pettingzoo_connect_four_specs: &pettingzoo_connect_four_specs
+    implementation: pettingzoo/connect_four_v3
+    num_input: 84
+    num_action: 7
+  pettingzoo_backgammon_specs: &pettingzoo_backgammon_specs
+    implementation: pettingzoo/backgammon_v3
+    num_input: 198
+    num_action: 1353
+
+play:
+  implementation: play
+  config:
+    class_name: data_pb2.PlayRunConfig
+    # Set to true to have the ability to observe the run in the web client
+    observer: true
+    trial_count: 10
+    environment:
+      specs: *atari_pitfall_specs
+      config:
+        player_count: 1
+    actors:
+    # Configure the players (only the first ones are used, up to the number of required players)
+    - name: agent_1
+      actor_class: agent
+      implementation: random
+      # To use an already trained agent use the following.
+      # Make sure the model is compatible with the implementation and the environment
+      #implementation: dqn
+      #agent_config:
+      #  model_id: dreamy_lamarr_model
+      #  model_version: 5
+    - name: agent_2
+      actor_class: agent
+      implementation: random
+
 cartpole_rainbow: &default_params
   implementation: "cogment_verse_run_impl"
   config: &default_config
     class_name: data_pb2.RunConfig
     environment:
-      specs:
-        implementation: gym/CartPole-v0
-        num_input: 4
-        num_action: 2
+      specs: *cartpole_specs
       config: &default_env_config
         player_count: 1
         render_width: 256
@@ -54,10 +131,7 @@ pendulum_td3:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/Pendulum-v0
-        num_input: 3
-        num_action: 1
+      specs: *pendulum_specs
       config: *default_env_config
     agent_implementation: td3
     epsilon_min: 0.0
@@ -80,10 +154,7 @@ minatar_breakout_rainbow:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: min/breakout
-        num_input: 500
-        num_action: 6
+      specs: *minatar_breakout_specs
       config: *default_env_config
     agent_implementation: rainbowtorch
 
@@ -92,10 +163,7 @@ atari_pitfall_rainbow:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: ata/Pitfall
-        num_input: 7056
-        num_action: 18
+      specs: *atari_pitfall_specs
       config: *default_env_config
     agent_implementation: rainbowtorch
 
@@ -104,10 +172,7 @@ atari_breakout_cnn:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: ata/Breakout
-        num_input: 7056
-        num_action: 4
+      specs: *atari_breakout_specs
       config:
         <<: *default_env_config
         flatten: false
@@ -136,10 +201,7 @@ minatar_breakout_demo:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: min/breakout
-        num_input: 400
-        num_action: 6
+      specs: *minatar_breakout_specs
       config: *default_env_config
     agent_implementation: rainbowtorch
 
@@ -148,10 +210,7 @@ atari_breakout_demo:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: ata/Breakout
-        num_input: 7056
-        num_action: 4
+      specs: *atari_breakout_specs
       config:
         <<: *default_env_config
         framestack: 4
@@ -162,10 +221,7 @@ atari_pitfall_demo:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: ata/Pitfall
-        num_input: 7056
-        num_action: 18
+      specs: *atari_pitfall_specs
       config: *default_env_config
     agent_implementation: rainbowtorch
     demonstration_count: 10
@@ -175,10 +231,7 @@ lander_rainbow_demo: &lander_rainbow_demo
   config: &lander_rainbow_config
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/LunarLander-v2
-        num_input: 8
-        num_action: 4
+      specs: *lander_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -208,10 +261,7 @@ tetris_rainbow_demo:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: tet/TetrisA-v0
-        num_input: 7056
-        num_action: 12
+      specs: *tetris_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -234,10 +284,7 @@ connect_four_rainbow:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: pet/connect_four_v3
-        num_input: 84
-        num_action: 7
+      specs: *pettingzoo_connect_four_specs
       config:
         <<: *default_env_config
         player_count: 2
@@ -272,10 +319,7 @@ benchmark_lander:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/LunarLander-v2
-        num_input: 8
-        num_action: 4
+      specs: *lander_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -299,10 +343,7 @@ benchmark_lander_hill:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/LunarLander-v2
-        num_input: 8
-        num_action: 4
+      specs: *lander_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -326,10 +367,7 @@ lander_continuous_td3:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/LunarLanderContinuous-v2
-        num_input: 8
-        num_action: 2
+      specs: *lander_continuous_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -361,10 +399,7 @@ lander_continuous_ddpg:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/LunarLanderContinuous-v2
-        num_input: 8
-        num_action: 2
+      specs: *lander_continuous_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -395,10 +430,7 @@ walker_td3:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/BipedalWalker-v3
-        num_input: 8
-        num_action: 2
+      specs: *bipedal_walker_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -429,10 +461,7 @@ walker_ddpg:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: gym/BipedalWalker-v3
-        num_input: 24
-        num_action: 4
+      specs: *bipedal_walker_specs
       config:
         <<: *default_env_config
         render_width: 1000
@@ -529,10 +558,7 @@ benchmark_breakout:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: min/breakout
-        num_input: 400
-        num_action: 6
+      specs: *minatar_breakout_specs
       config: *default_env_config
     agent_implementation: rainbowtorch
     demonstration_count: 0
@@ -549,10 +575,7 @@ benchmark_connect_four:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: pet/connect_four_v3
-        num_input: 84
-        num_action: 7
+      specs: *pettingzoo_connect_four_specs
       config:
         <<: *default_env_config
         player_count: 2
@@ -574,10 +597,7 @@ simple_a2c_cartpole: &default_simple_a2c_params
   config: &default_simple_a2c_config
     class_name: data_pb2.SimpleA2CTrainingRunConfig
     environment:
-      specs:
-        implementation: gym/CartPole-v0
-        num_input: 4
-        num_action: 2
+      specs: *cartpole_specs
       config:
         <<: *default_env_config
         seed: 12
@@ -602,10 +622,7 @@ procgen_bigfish:
   config:
     <<: *default_config
     environment:
-      specs:
-        implementation: procgen/bigfish
-        num_input: 7056
-        num_action: 15
+      specs: *procgen_bigfish_specs
       config:
         <<: *default_env_config
         render_width: 64
@@ -637,10 +654,7 @@ simple_bc_lander: &simple_bc_experiment
   config: &simple_bc_config
     class_name: data_pb2.SimpleBCTrainingRunConfig
     environment:
-      specs:
-        implementation: gym/LunarLander-v2
-        num_input: 8
-        num_action: 4
+      specs: *lander_specs
       config:
         seed: 12
     training:
@@ -657,10 +671,7 @@ simple_bc_cartpole:
   config:
     <<: *simple_bc_config
     environment:
-      specs:
-        implementation: gym/CartPole-v0
-        num_input: 4
-        num_action: 2
+      specs: *cartpole_specs
       config:
         seed: 12
 
@@ -670,34 +681,6 @@ simple_bc_mountaincar:
   config:
     <<: *simple_bc_config
     environment:
-      specs:
-        implementation: gym/MountainCar-v0
-        num_input: 2
-        num_action: 3
+      specs: *mountain_car_specs
       config:
         seed: 12
-
-play:
-  implementation: play
-  config:
-    class_name: data_pb2.PlayRunConfig
-    # Set to true to have the ability to observe the run in the web client
-    observer: true
-    trial_count: 10
-    environment:
-      specs:
-        implementation: gym/LunarLander-v2
-        num_input: 8
-        num_action: 4
-      config:
-        player_count: 1
-    actors:
-    - name: player_1
-      actor_class: agent
-      implementation: random
-      # To use an already trained agent use the following.
-      # Make sure the model is compatible with the implementation and the environment
-      #implementation: dqn
-      #agent_config:
-      #  model_id: dreamy_lamarr_model
-      #  model_version: 5

--- a/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
+++ b/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
@@ -15,7 +15,7 @@
 import logging
 
 from cogment_verse import MlflowExperimentTracker
-from data_pb2 import ActorConfig, ActorParams, EnvironmentConfig, EnvironmentParams, TrialConfig
+from data_pb2 import AgentConfig, ActorParams, EnvironmentConfig, EnvironmentParams, EnvironmentSpecs, TrialConfig
 from google.protobuf.json_format import MessageToDict
 
 # pylint: disable=protected-access
@@ -51,19 +51,23 @@ def create_training_run(agent_adapter):
             trials_completed = 0
             all_trials_reward = 0
 
+            environment_specs = EnvironmentSpecs(
+                implementation=config.environment_implementation,
+                num_input=config.num_input,
+                num_action=config.num_action,
+            )
+
             # Create config for the actor
             actor_configs = [
                 ActorParams(
                     name=f"reinforce_player_{player_idx}",
                     actor_class="agent",
                     implementation=config.agent_implementation,
-                    config=ActorConfig(
+                    agent_config=AgentConfig(
+                        run_id=run_id,
                         model_id=model_id,
                         model_version=model_version_number,
-                        run_id=run_id,
-                        environment_implementation=config.environment_implementation,
-                        num_input=config.num_input,
-                        num_action=config.num_action,
+                        environment_specs=environment_specs,
                     ),
                 )
                 for player_idx in range(config.player_count)
@@ -74,7 +78,7 @@ def create_training_run(agent_adapter):
                 TrialConfig(
                     run_id=run_id,
                     environment=EnvironmentParams(
-                        implementation=config.environment_implementation,
+                        specs=environment_specs,
                         config=EnvironmentConfig(
                             player_count=config.player_count,
                             run_id=run_id,

--- a/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
+++ b/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
@@ -64,7 +64,7 @@ def create_training_run(agent_adapter):
                         environment_specs=config.environment.specs,
                     ),
                 )
-                for player_idx in range(config.environment.config.player_count)
+                for player_idx in range(config.environment.specs.num_players)
             ]
 
             # Create configs for trials
@@ -74,7 +74,6 @@ def create_training_run(agent_adapter):
                     environment=EnvironmentParams(
                         specs=config.environment.specs,
                         config=EnvironmentConfig(
-                            player_count=config.environment.config.player_count,
                             run_id=run_id,
                             render=False,
                             render_width=config.environment.config.render_width,

--- a/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
+++ b/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
@@ -15,7 +15,7 @@
 import logging
 
 from cogment_verse import MlflowExperimentTracker
-from data_pb2 import AgentConfig, ActorParams, EnvironmentConfig, EnvironmentParams, EnvironmentSpecs, TrialConfig
+from data_pb2 import AgentConfig, ActorParams, EnvironmentConfig, EnvironmentParams, TrialConfig
 from google.protobuf.json_format import MessageToDict
 
 # pylint: disable=protected-access

--- a/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
+++ b/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
@@ -36,9 +36,8 @@ def create_training_run(agent_adapter):
             model_kwargs = MessageToDict(config.model_kwargs, preserving_proto_field_name=True)
             model, _ = await agent_adapter.create_and_publish_initial_version(
                 model_id,
+                environment_specs=config.environment.specs,
                 **{
-                    "obs_dim": config.environment.specs.num_input,
-                    "act_dim": config.environment.specs.num_action,
                     "max_replay_buffer_size": config.max_replay_buffer_size,
                     "lr": config.learning_rate,
                     "gamma": config.discount_factor,

--- a/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
+++ b/tf_agents/cogment_verse_tf_agents/reinforce/training_run.py
@@ -37,8 +37,8 @@ def create_training_run(agent_adapter):
             model, _ = await agent_adapter.create_and_publish_initial_version(
                 model_id,
                 **{
-                    "obs_dim": config.num_input,
-                    "act_dim": config.num_action,
+                    "obs_dim": config.environment.specs.num_input,
+                    "act_dim": config.environment.specs.num_action,
                     "max_replay_buffer_size": config.max_replay_buffer_size,
                     "lr": config.learning_rate,
                     "gamma": config.discount_factor,
@@ -51,12 +51,6 @@ def create_training_run(agent_adapter):
             trials_completed = 0
             all_trials_reward = 0
 
-            environment_specs = EnvironmentSpecs(
-                implementation=config.environment_implementation,
-                num_input=config.num_input,
-                num_action=config.num_action,
-            )
-
             # Create config for the actor
             actor_configs = [
                 ActorParams(
@@ -67,10 +61,10 @@ def create_training_run(agent_adapter):
                         run_id=run_id,
                         model_id=model_id,
                         model_version=model_version_number,
-                        environment_specs=environment_specs,
+                        environment_specs=config.environment.specs,
                     ),
                 )
-                for player_idx in range(config.player_count)
+                for player_idx in range(config.environment.config.player_count)
             ]
 
             # Create configs for trials
@@ -78,14 +72,14 @@ def create_training_run(agent_adapter):
                 TrialConfig(
                     run_id=run_id,
                     environment=EnvironmentParams(
-                        specs=environment_specs,
+                        specs=config.environment.specs,
                         config=EnvironmentConfig(
-                            player_count=config.player_count,
+                            player_count=config.environment.config.player_count,
                             run_id=run_id,
                             render=False,
-                            render_width=config.render_width,
-                            flatten=config.flatten,
-                            framestack=config.framestack,
+                            render_width=config.environment.config.render_width,
+                            flatten=config.environment.config.flatten,
+                            framestack=config.environment.config.framestack,
                         ),
                     ),
                     actors=actor_configs,

--- a/tf_agents/main.py
+++ b/tf_agents/main.py
@@ -30,6 +30,7 @@ PORT = int(os.getenv("COGMENT_VERSE_TF_AGENTS_PORT", "9000"))
 PROMETHEUS_PORT = int(os.getenv("COGMENT_VERSE_TF_AGENTS_PROMETHEUS_PORT", "8000"))
 
 TRIAL_DATASTORE_ENDPOINT = os.getenv("COGMENT_VERSE_TRIAL_DATASTORE_ENDPOINT")
+MODEL_REGISTRY_ENDPOINT = os.getenv("COGMENT_VERSE_MODEL_REGISTRY_ENDPOINT")
 ORCHESTRATOR_ENDPOINT = os.getenv("COGMENT_VERSE_ORCHESTRATOR_ENDPOINT")
 ACTOR_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ACTOR_ENDPOINTS"))
 ENVIRONMENT_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ENVIRONMENT_ENDPOINTS"))
@@ -46,6 +47,7 @@ async def main():
         services_endpoints={
             "orchestrator": ORCHESTRATOR_ENDPOINT,
             "trial_datastore": TRIAL_DATASTORE_ENDPOINT,
+            "model_registry": MODEL_REGISTRY_ENDPOINT,
             **ACTOR_ENDPOINTS,
             **ENVIRONMENT_ENDPOINTS,
         },
@@ -64,5 +66,5 @@ if __name__ == "__main__":
     try:
         loop.run_until_complete(main())
     except KeyboardInterrupt:
-        print("process interrupted")
+        log.error("process interrupted")
         sys.exit(-1)

--- a/torch_agents/cogment_verse_torch_agents/hive_adapter/hive_agent_adapter.py
+++ b/torch_agents/cogment_verse_torch_agents/hive_adapter/hive_agent_adapter.py
@@ -118,7 +118,7 @@ class HiveAgentAdapter(AgentAdapter):
 
                             obs_input = obs["vectorized"]
                             legal_moves_input = format_legal_moves(
-                                obs["legal_moves_as_int"], actor_session.config.num_action
+                                obs["legal_moves_as_int"], actor_session.config.environment_specs.num_action
                             )
 
                             if obs["current_player"] != actor_index:

--- a/torch_agents/cogment_verse_torch_agents/hive_adapter/sample_producer.py
+++ b/torch_agents/cogment_verse_torch_agents/hive_adapter/sample_producer.py
@@ -86,7 +86,10 @@ async def sample_producer(run_sample_producer_session):
                 run_sample_producer_session.produce_training_sample(
                     TrainingSample(
                         current_player_sample=vectorized_training_sample_from_samples(
-                            previous_sample, sample, last_tick, run_sample_producer_session.run_config.num_action
+                            previous_sample,
+                            sample,
+                            last_tick,
+                            run_sample_producer_session.run_config.environment.specs.num_action,
                         ),
                         trial_total_reward=trial_total_reward if last_tick else None,
                     ),

--- a/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
+++ b/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
@@ -91,7 +91,6 @@ def create_training_run(agent_adapter):
             )
             run_xp_tracker.log_params(
                 model._params,
-                player_count=config.environment.config.player_count,
                 batch_size=config.batch_size,
                 model_publication_interval=config.model_publication_interval,
                 model_archive_interval_multiplier=config.model_archive_interval_multiplier,
@@ -126,11 +125,11 @@ def create_training_run(agent_adapter):
                         environment_specs=config.environment.specs,
                     ),
                 )
-                for player_idx in range(config.environment.config.player_count)
+                for player_idx in range(config.environment.specs.num_players)
             ]
             # for self-play, randomly select one player to use latest model version
             # if there is only one player then it will always use the latest
-            distinguished_actor = np.random.randint(0, config.environment.config.player_count)
+            distinguished_actor = np.random.randint(0, config.environment.specs.num_players)
             player_actor_configs[distinguished_actor].agent_config.model_version = -1
 
             self_play_trial_configs = [
@@ -139,7 +138,6 @@ def create_training_run(agent_adapter):
                     environment=EnvironmentParams(
                         specs=config.environment.specs,
                         config=EnvironmentConfig(
-                            player_count=config.environment.config.player_count,
                             run_id=run_id,
                             render=False,
                             render_width=config.environment.config.render_width,
@@ -171,7 +169,6 @@ def create_training_run(agent_adapter):
                         environment=EnvironmentParams(
                             specs=config.environment.specs,
                             config=EnvironmentConfig(
-                                player_count=config.environment.config.player_count,
                                 run_id=run_id,
                                 render=True,
                                 render_width=config.environment.config.render_width,

--- a/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
+++ b/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
@@ -27,11 +27,12 @@ from cogment_verse_torch_agents.third_party.hive.utils.schedule import (
     SwitchSchedule,
 )
 from data_pb2 import (
-    AgentConfig,
     ActorParams,
+    AgentConfig,
     EnvironmentConfig,
     EnvironmentParams,
     HumanConfig,
+    HumanRole,
     TrialConfig,
 )
 from google.protobuf.json_format import MessageToDict
@@ -160,6 +161,7 @@ def create_training_run(agent_adapter):
                     human_config=HumanConfig(
                         run_id=run_id,
                         environment_specs=config.environment.specs,
+                        role=HumanRole.TEACHER,
                     ),
                 )
                 demonstration_trial_configs = [

--- a/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
+++ b/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
@@ -31,7 +31,6 @@ from data_pb2 import (
     ActorParams,
     EnvironmentConfig,
     EnvironmentParams,
-    EnvironmentSpecs,
     TeacherConfig,
     TrialConfig,
 )

--- a/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
+++ b/torch_agents/cogment_verse_torch_agents/hive_adapter/training_run.py
@@ -31,7 +31,7 @@ from data_pb2 import (
     ActorParams,
     EnvironmentConfig,
     EnvironmentParams,
-    TeacherConfig,
+    HumanConfig,
     TrialConfig,
 )
 from google.protobuf.json_format import MessageToDict
@@ -78,9 +78,8 @@ def create_training_run(agent_adapter):
             model, _ = await agent_adapter.create_and_publish_initial_version(
                 model_id,
                 impl_name=config.agent_implementation,
+                environment_specs=config.environment.specs,
                 **{
-                    "obs_dim": config.environment.specs.num_input,
-                    "act_dim": config.environment.specs.num_action,
                     "epsilon_schedule": LinearSchedule(1, config.epsilon_min, config.epsilon_steps),
                     "learn_schedule": SwitchSchedule(False, True, 1),
                     "target_net_update_schedule": PeriodicSchedule(False, True, config.target_net_update_schedule),
@@ -158,7 +157,7 @@ def create_training_run(agent_adapter):
                     name="web_actor",
                     actor_class="teacher_agent",
                     implementation="client",
-                    teacher_config=TeacherConfig(
+                    human_config=HumanConfig(
                         run_id=run_id,
                         environment_specs=config.environment.specs,
                     ),

--- a/torch_agents/cogment_verse_torch_agents/simple_a2c/simple_a2c_agent.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_a2c/simple_a2c_agent.py
@@ -47,24 +47,23 @@ class SimpleA2CAgentAdapter(AgentAdapter):
     def _create(
         self,
         model_id,
-        observation_size,
-        action_count,
+        environment_specs,
         actor_network_hidden_size=64,
         critic_network_hidden_size=64,
         **kwargs,
     ):
-        return SimpleA2CModel(
+        model = SimpleA2CModel(
             model_id=model_id,
             version_number=1,
             actor_network=torch.nn.Sequential(
-                torch.nn.Linear(observation_size, actor_network_hidden_size),
+                torch.nn.Linear(environment_specs.num_input, actor_network_hidden_size),
                 torch.nn.Tanh(),
                 torch.nn.Linear(actor_network_hidden_size, actor_network_hidden_size),
                 torch.nn.Tanh(),
-                torch.nn.Linear(actor_network_hidden_size, action_count),
+                torch.nn.Linear(actor_network_hidden_size, environment_specs.num_action),
             ).to(self._dtype),
             critic_network=torch.nn.Sequential(
-                torch.nn.Linear(observation_size, critic_network_hidden_size),
+                torch.nn.Linear(environment_specs.num_input, critic_network_hidden_size),
                 torch.nn.Tanh(),
                 torch.nn.Linear(critic_network_hidden_size, critic_network_hidden_size),
                 torch.nn.Tanh(),
@@ -72,18 +71,37 @@ class SimpleA2CAgentAdapter(AgentAdapter):
             ).to(self._dtype),
         )
 
-    def _load(self, model_id, version_number, version_user_data, model_data_f):
+        model_user_data = {
+            "environment_implementation": environment_specs.implementation,
+            "num_input": environment_specs.num_input,
+            "num_action": environment_specs.num_action,
+        }
+
+        return model, model_user_data
+
+    def _load(
+        self,
+        model_id,
+        version_number,
+        model_user_data,
+        version_user_data,
+        model_data_f,
+        environment_specs,
+        **kwargs,
+    ):
         (actor_network, critic_network) = torch.load(model_data_f)
+        assert model_user_data["environment_implementation"] == environment_specs.implementation
         assert isinstance(actor_network, torch.nn.Sequential)
         assert isinstance(critic_network, torch.nn.Sequential)
         return SimpleA2CModel(
             model_id=model_id, version_number=version_number, actor_network=actor_network, critic_network=critic_network
         )
 
-    def _save(self, model, model_data_f):
+    def _save(self, model, model_user_data, model_data_f, environment_specs, epoch_idx=-1, total_samples=0, **kwargs):
+        assert model_user_data["environment_implementation"] == environment_specs.implementation
         assert isinstance(model, SimpleA2CModel)
         torch.save((model.actor_network, model.critic_network), model_data_f)
-        return {}
+        return {"epoch_idx": epoch_idx, "total_samples": total_samples}
 
     def _create_actor_implementations(self):
         async def impl(actor_session):
@@ -91,7 +109,9 @@ class SimpleA2CAgentAdapter(AgentAdapter):
 
             config = actor_session.config
 
-            model, _ = await self.retrieve_version(config.model_id, config.model_version)
+            model, _, _ = await self.retrieve_version(
+                config.model_id, config.model_version, environment_specs=config.environment_specs
+            )
 
             async for event in actor_session.event_loop():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
@@ -137,8 +157,7 @@ class SimpleA2CAgentAdapter(AgentAdapter):
 
             model, _ = await self.create_and_publish_initial_version(
                 model_id,
-                observation_size=config.environment.specs.num_input,
-                action_count=config.environment.specs.num_action,
+                environment_specs=config.environment.specs,
                 actor_network_hidden_size=config.actor_network.hidden_size,
                 critic_network_hidden_size=config.critic_network.hidden_size,
             )
@@ -147,7 +166,7 @@ class SimpleA2CAgentAdapter(AgentAdapter):
             xp_tracker.log_params(
                 config.training,
                 config.environment.config,
-                environment=config.environment.specs.implementation,
+                environment_implementation=config.environment.specs.implementation,
                 actor_network_hidden_size=config.actor_network.hidden_size,
                 critic_network_hidden_size=config.critic_network.hidden_size,
             )
@@ -159,7 +178,7 @@ class SimpleA2CAgentAdapter(AgentAdapter):
             )
 
             total_samples = 0
-            for epoch in range(config.training.epoch_count):
+            for epoch_idx in range(config.training.epoch_count):
                 # Rollout a bunch of trials
                 observation = []
                 action = []
@@ -206,6 +225,12 @@ class SimpleA2CAgentAdapter(AgentAdapter):
 
                     xp_tracker.log_metrics(step_timestamp, step_idx, total_reward=sum([r.item() for r in trial_reward]))
 
+                if len(observation) == 0:
+                    log.warning(
+                        f"[{run_session.params_name}/{run_session.run_id}] epoch #{epoch_idx + 1}/{config.training.epoch_count} finished without generating any sample (every trial ended at the first tick), skipping training."
+                    )
+                    continue
+
                 total_samples += len(observation)
 
                 # Convert the accumulated observation/action/reward over the epoch to tensors
@@ -246,13 +271,21 @@ class SimpleA2CAgentAdapter(AgentAdapter):
                 optimizer.step()
 
                 # Publish the newly trained version
-                version_info = await self.publish_version(model_id, model)
+                last_epoch = epoch_idx + 1 == config.training.epoch_count
+                version_info = await self.publish_version(
+                    model_id,
+                    model,
+                    archived=last_epoch,
+                    epoch_idx=epoch_idx,
+                    total_samples=total_samples,
+                    environment_specs=config.environment.specs,
+                )
                 model_version_number = version_info["version_number"]
                 xp_tracker.log_metrics(
                     epoch_last_step_timestamp,
                     epoch_last_step_idx,
                     model_version_number=model_version_number,
-                    epoch=epoch,
+                    epoch_idx=epoch_idx,
                     entropy_loss=entropy_loss.item(),
                     value_loss=value_loss.item(),
                     action_loss=action_loss.item(),
@@ -260,7 +293,7 @@ class SimpleA2CAgentAdapter(AgentAdapter):
                     total_samples=total_samples,
                 )
                 log.info(
-                    f"[{run_session.params_name}/{run_session.run_id}] epoch #{epoch} finished ({total_samples} samples seen)"
+                    f"[{run_session.params_name}/{run_session.run_id}] epoch #{epoch_idx + 1}/{config.training.epoch_count} finished ({total_samples} samples seen)"
                 )
 
         return {

--- a/torch_agents/cogment_verse_torch_agents/simple_a2c/simple_a2c_agent.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_a2c/simple_a2c_agent.py
@@ -133,7 +133,7 @@ class SimpleA2CAgentAdapter(AgentAdapter):
             model_id = f"{run_session.run_id}_model"
 
             config = run_session.config
-            assert config.environment.config.player_count == 1
+            assert config.environment.specs.num_players == 1
 
             model, _ = await self.create_and_publish_initial_version(
                 model_id,
@@ -274,7 +274,7 @@ class SimpleA2CAgentAdapter(AgentAdapter):
                             num_input=4,
                             num_action=2,
                         ),
-                        config=EnvironmentConfig(seed=12, player_count=1, framestack=1),
+                        config=EnvironmentConfig(seed=12, framestack=1),
                     ),
                     training=SimpleA2CTrainingConfig(
                         epoch_count=100,

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
@@ -28,8 +28,9 @@ from data_pb2 import (
     EnvironmentConfig,
     EnvironmentParams,
     EnvironmentSpecs,
-    SimpleBCTrainingRunConfig,
     HumanConfig,
+    HumanRole,
+    SimpleBCTrainingRunConfig,
     TrialConfig,
 )
 
@@ -107,6 +108,7 @@ class SimpleBCAgentAdapterTutorialStep1(AgentAdapter):
                     implementation="client",
                     human_config=HumanConfig(
                         environment_specs=env_params.specs,
+                        role=HumanRole.TEACHER,
                     ),
                 )
 

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
@@ -29,7 +29,7 @@ from data_pb2 import (
     EnvironmentParams,
     EnvironmentSpecs,
     SimpleBCTrainingRunConfig,
-    TeacherConfig,
+    HumanConfig,
     TrialConfig,
 )
 
@@ -48,19 +48,6 @@ class SimpleBCAgentAdapterTutorialStep1(AgentAdapter):
         """Run a given function asynchronously in the default thread pool"""
         event_loop = asyncio.get_running_loop()
         return await event_loop.run_in_executor(None, func, *args)
-
-    def _create(
-        self,
-        model_id,
-        **kwargs,
-    ):
-        raise NotImplementedError
-
-    def _load(self, model_id, version_number, version_user_data, model_data_f):
-        raise NotImplementedError
-
-    def _save(self, model, model_data_f):
-        raise NotImplementedError
 
     def _create_actor_implementations(self):
         async def impl(actor_session):
@@ -118,7 +105,7 @@ class SimpleBCAgentAdapterTutorialStep1(AgentAdapter):
                     name="web_actor",
                     actor_class="teacher_agent",
                     implementation="client",
-                    teacher_config=TeacherConfig(
+                    human_config=HumanConfig(
                         environment_specs=env_params.specs,
                     ),
                 )

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_1.py
@@ -91,7 +91,7 @@ class SimpleBCAgentAdapterTutorialStep1(AgentAdapter):
             xp_tracker = MlflowExperimentTracker(run_session.params_name, run_session.run_id)
 
             config = run_session.config
-            assert config.environment.config.player_count == 1
+            assert config.environment.specs.num_players == 1
 
             xp_tracker.log_params(
                 config.training,
@@ -149,7 +149,7 @@ class SimpleBCAgentAdapterTutorialStep1(AgentAdapter):
                 SimpleBCTrainingRunConfig(
                     environment=EnvironmentParams(
                         specs=EnvironmentSpecs(implementation="gym/LunarLander-v2", num_input=8, num_action=4),
-                        config=EnvironmentConfig(seed=12, player_count=1, framestack=1, render=True, render_width=256),
+                        config=EnvironmentConfig(seed=12, framestack=1, render=True, render_width=256),
                     )
                 ),
             )

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
@@ -32,7 +32,7 @@ from data_pb2 import (
     EnvironmentParams,
     EnvironmentSpecs,
     SimpleBCTrainingRunConfig,
-    TeacherConfig,
+    HumanConfig,
     TrialConfig,
 )
 
@@ -54,19 +54,6 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
         """Run a given function asynchronously in the default thread pool"""
         event_loop = asyncio.get_running_loop()
         return await event_loop.run_in_executor(None, func, *args)
-
-    def _create(
-        self,
-        model_id,
-        **kwargs,
-    ):
-        raise NotImplementedError
-
-    def _load(self, model_id, version_number, version_user_data, model_data_f):
-        raise NotImplementedError
-
-    def _save(self, model, model_data_f):
-        raise NotImplementedError
 
     def _create_actor_implementations(self):
         async def impl(actor_session):
@@ -140,7 +127,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
                     name="web_actor",
                     actor_class="teacher_agent",
                     implementation="client",
-                    teacher_config=TeacherConfig(
+                    human_config=HumanConfig(
                         environment_specs=env_params.specs,
                     ),
                 )

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
@@ -113,7 +113,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
             xp_tracker = MlflowExperimentTracker(run_session.params_name, run_session.run_id)
 
             config = run_session.config
-            assert config.environment.config.player_count == 1
+            assert config.environment.specs.num_players == 1
 
             xp_tracker.log_params(
                 config.training,
@@ -171,7 +171,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
                 SimpleBCTrainingRunConfig(
                     environment=EnvironmentParams(
                         specs=EnvironmentSpecs(implementation="gym/LunarLander-v2", num_input=8, num_action=4),
-                        config=EnvironmentConfig(seed=12, player_count=1, framestack=1, render=True, render_width=256),
+                        config=EnvironmentConfig(seed=12, framestack=1, render=True, render_width=256),
                     )
                 ),
             )

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
@@ -31,8 +31,9 @@ from data_pb2 import (
     EnvironmentConfig,
     EnvironmentParams,
     EnvironmentSpecs,
-    SimpleBCTrainingRunConfig,
     HumanConfig,
+    HumanRole,
+    SimpleBCTrainingRunConfig,
     TrialConfig,
 )
 
@@ -129,6 +130,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
                     implementation="client",
                     human_config=HumanConfig(
                         environment_specs=env_params.specs,
+                        role=HumanRole.TEACHER,
                     ),
                 )
 

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_2.py
@@ -21,14 +21,22 @@ import numpy as np
 import torch
 from cogment.api.common_pb2 import TrialState
 from cogment_verse import AgentAdapter, MlflowExperimentTracker
+
 ############ TUTORIAL STEP 2 ############
 from cogment_verse_torch_agents.utils.tensors import tensor_from_cog_action, tensor_from_cog_obs
-from data_pb2 import (ActorConfig, ActorParams, AgentAction, EnvironmentConfig, EnvironmentParams,
-                      SimpleBCTrainingRunConfig, TrialConfig)
+from data_pb2 import (
+    ActorParams,
+    AgentAction,
+    AgentConfig,
+    EnvironmentConfig,
+    EnvironmentParams,
+    EnvironmentSpecs,
+    SimpleBCTrainingRunConfig,
+    TeacherConfig,
+    TrialConfig,
+)
 
 ##########################################
-
-
 
 
 log = logging.getLogger(__name__)
@@ -68,7 +76,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
 
             async for event in actor_session.event_loop():
                 if event.observation and event.type == cogment.EventType.ACTIVE:
-                    action = np.random.default_rng().integers(0, config.num_action)
+                    action = np.random.default_rng().integers(0, config.environment_specs.num_action)
                     actor_session.do_action(AgentAction(discrete_action=action))
 
         return {
@@ -110,7 +118,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
             xp_tracker.log_params(
                 config.training,
                 config.environment.config,
-                environment=config.environment.implementation,
+                environment=config.environment.specs.implementation,
                 policy_network_hidden_size=config.policy_network.hidden_size,
             )
 
@@ -122,10 +130,9 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
                     name="agent_1",
                     actor_class="agent",
                     implementation="simple_bc",
-                    config=ActorConfig(
-                        num_input=config.actor.num_input,
-                        num_action=config.actor.num_action,
-                        environment_implementation=config.environment.implementation,
+                    agent_config=AgentConfig(
+                        run_id=run_session.run_id,
+                        environment_specs=env_params.specs,
                     ),
                 )
 
@@ -133,10 +140,8 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
                     name="web_actor",
                     actor_class="teacher_agent",
                     implementation="client",
-                    config=ActorConfig(
-                        num_input=config.actor.num_input,
-                        num_action=config.actor.num_action,
-                        environment_implementation=config.environment.implementation,
+                    teacher_config=TeacherConfig(
+                        environment_specs=env_params.specs,
                     ),
                 )
 
@@ -165,7 +170,7 @@ class SimpleBCAgentAdapterTutorialStep2(AgentAdapter):
                 run_impl,
                 SimpleBCTrainingRunConfig(
                     environment=EnvironmentParams(
-                        implementation="gym/LunarLander-v2",
+                        specs=EnvironmentSpecs(implementation="gym/LunarLander-v2", num_input=8, num_action=4),
                         config=EnvironmentConfig(seed=12, player_count=1, framestack=1, render=True, render_width=256),
                     )
                 ),

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
@@ -34,6 +34,8 @@ from data_pb2 import (
     EnvironmentConfig,
     EnvironmentParams,
     EnvironmentSpecs,
+    HumanConfig,
+    HumanRole,
     MLPNetworkConfig,
     SimpleBCTrainingRunConfig,
     TrialConfig,
@@ -203,8 +205,9 @@ class SimpleBCAgentAdapterTutorialStep3(AgentAdapter):
                     name="web_actor",
                     actor_class="teacher_agent",
                     implementation="client",
-                    agent_config=AgentConfig(
+                    human_config=HumanConfig(
                         environment_specs=env_params.specs,
+                        role=HumanRole.TEACHER,
                     ),
                 )
 

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
@@ -63,31 +63,38 @@ class SimpleBCAgentAdapterTutorialStep3(AgentAdapter):
     def _create(
         self,
         model_id,
-        observation_size,
-        action_count,
+        environment_specs,
         policy_network_hidden_size=64,
         **kwargs,
     ):
-        return SimpleBCModel(
+        model = SimpleBCModel(
             model_id=model_id,
             version_number=1,
             policy_network=torch.nn.Sequential(
-                torch.nn.Linear(observation_size, policy_network_hidden_size),
+                torch.nn.Linear(environment_specs.num_input, policy_network_hidden_size),
                 torch.nn.BatchNorm1d(policy_network_hidden_size),
                 torch.nn.ReLU(),
                 torch.nn.Linear(policy_network_hidden_size, policy_network_hidden_size),
                 torch.nn.BatchNorm1d(policy_network_hidden_size),
                 torch.nn.ReLU(),
-                torch.nn.Linear(policy_network_hidden_size, action_count),
+                torch.nn.Linear(policy_network_hidden_size, environment_specs.num_action),
             ).to(self._dtype),
         )
 
-    def _load(self, model_id, version_number, version_user_data, model_data_f):
+        model_user_data = {
+            "environment_implementation": environment_specs.implementation,
+            "num_input": environment_specs.num_input,
+            "num_action": environment_specs.num_action,
+        }
+
+        return model, model_user_data
+
+    def _load(self, model_id, version_number, model_user_data, version_user_data, model_data_f, **kwargs):
         policy_network = torch.load(model_data_f)
         assert isinstance(policy_network, torch.nn.Sequential)
         return SimpleBCModel(model_id=model_id, version_number=version_number, policy_network=policy_network)
 
-    def _save(self, model, model_data_f):
+    def _save(self, model, model_user_data, model_data_f, **kwargs):
         assert isinstance(model, SimpleBCModel)
         torch.save(model.policy_network, model_data_f)
         return {}
@@ -101,7 +108,7 @@ class SimpleBCAgentAdapterTutorialStep3(AgentAdapter):
             config = actor_session.config
 
             ############ TUTORIAL STEP 3 ############
-            model, version_info = await self.retrieve_version(config.model_id, config.model_version)
+            model, _model_info, version_info = await self.retrieve_version(config.model_id, config.model_version)
             model_version_number = version_info["version_number"]
             log.info(f"Starting trial with model v{model_version_number}")
 
@@ -169,8 +176,7 @@ class SimpleBCAgentAdapterTutorialStep3(AgentAdapter):
             # Initializing a model
             _model, _version_info = await self.create_and_publish_initial_version(
                 model_id,
-                observation_size=config.environment.specs.num_input,
-                action_count=config.environment.specs.num_action,
+                environment_specs=config.environment.specs,
                 policy_network_hidden_size=config.policy_network.hidden_size,
             )
             ##########################################

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_3.py
@@ -154,7 +154,7 @@ class SimpleBCAgentAdapterTutorialStep3(AgentAdapter):
             xp_tracker = MlflowExperimentTracker(run_session.params_name, run_session.run_id)
 
             config = run_session.config
-            assert config.environment.config.player_count == 1
+            assert config.environment.specs.num_players == 1
 
             xp_tracker.log_params(
                 config.training,
@@ -228,7 +228,7 @@ class SimpleBCAgentAdapterTutorialStep3(AgentAdapter):
                 SimpleBCTrainingRunConfig(
                     environment=EnvironmentParams(
                         specs=EnvironmentSpecs(implementation="gym/LunarLander-v2", num_input=8, num_action=4),
-                        config=EnvironmentConfig(seed=12, player_count=1, framestack=1, render=True, render_width=256),
+                        config=EnvironmentConfig(seed=12, framestack=1, render=True, render_width=256),
                     ),
                     ############ TUTORIAL STEP 3 ############
                     policy_network=MLPNetworkConfig(hidden_size=64),

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_4.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_4.py
@@ -147,7 +147,7 @@ class SimpleBCAgentAdapterTutorialStep4(AgentAdapter):
             xp_tracker = MlflowExperimentTracker(run_session.params_name, run_session.run_id)
 
             config = run_session.config
-            assert config.environment.config.player_count == 1
+            assert config.environment.specs.num_players == 1
 
             xp_tracker.log_params(
                 config.training,
@@ -276,7 +276,7 @@ class SimpleBCAgentAdapterTutorialStep4(AgentAdapter):
                 SimpleBCTrainingRunConfig(
                     environment=EnvironmentParams(
                         specs=EnvironmentSpecs(implementation="gym/LunarLander-v2", num_input=8, num_action=4),
-                        config=EnvironmentConfig(seed=12, player_count=1, framestack=1, render=True, render_width=256),
+                        config=EnvironmentConfig(seed=12, framestack=1, render=True, render_width=256),
                     ),
                     ############ TUTORIAL STEP 4 ############
                     training=SimpleBCTrainingConfig(

--- a/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_4.py
+++ b/torch_agents/cogment_verse_torch_agents/simple_bc/tutorial_4.py
@@ -33,6 +33,8 @@ from data_pb2 import (
     EnvironmentConfig,
     EnvironmentParams,
     EnvironmentSpecs,
+    HumanConfig,
+    HumanRole,
     MLPNetworkConfig,
     ############ TUTORIAL STEP 4 ############
     SimpleBCTrainingConfig,
@@ -192,8 +194,9 @@ class SimpleBCAgentAdapterTutorialStep4(AgentAdapter):
                     name="web_actor",
                     actor_class="teacher_agent",
                     implementation="client",
-                    agent_config=AgentConfig(
+                    human_config=HumanConfig(
                         environment_specs=env_params.specs,
+                        role=HumanRole.TEACHER,
                     ),
                 )
 

--- a/torch_agents/main.py
+++ b/torch_agents/main.py
@@ -32,9 +32,11 @@ PORT = int(os.getenv("COGMENT_VERSE_TORCH_AGENTS_PORT", "9000"))
 PROMETHEUS_PORT = int(os.getenv("COGMENT_VERSE_TORCH_AGENTS_PROMETHEUS_PORT", "8000"))
 
 TRIAL_DATASTORE_ENDPOINT = os.getenv("COGMENT_VERSE_TRIAL_DATASTORE_ENDPOINT")
+MODEL_REGISTRY_ENDPOINT = os.getenv("COGMENT_VERSE_MODEL_REGISTRY_ENDPOINT")
 ORCHESTRATOR_ENDPOINT = os.getenv("COGMENT_VERSE_ORCHESTRATOR_ENDPOINT")
 ACTOR_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ACTOR_ENDPOINTS"))
 ENVIRONMENT_ENDPOINTS = json.loads(os.getenv("COGMENT_VERSE_ENVIRONMENT_ENDPOINTS"))
+
 
 logging.basicConfig(level=logging.INFO)
 
@@ -48,6 +50,7 @@ async def main():
         services_endpoints={
             "orchestrator": "grpc://" + ORCHESTRATOR_ENDPOINT,
             "trial_datastore": TRIAL_DATASTORE_ENDPOINT,
+            "model_registry": MODEL_REGISTRY_ENDPOINT,
             **ACTOR_ENDPOINTS,
             **ENVIRONMENT_ENDPOINTS,
         },
@@ -72,5 +75,5 @@ if __name__ == "__main__":
     try:
         loop.run_until_complete(main())
     except KeyboardInterrupt:
-        print("process interrupted")
+        log.error("process interrupted")
         sys.exit(-1)

--- a/torch_agents/tests/test_simple_a2c.py
+++ b/torch_agents/tests/test_simple_a2c.py
@@ -16,29 +16,50 @@ import io
 
 import torch
 from cogment_verse_torch_agents.simple_a2c.simple_a2c_agent import SimpleA2CAgentAdapter
+from data_pb2 import EnvironmentSpecs
 
 # pylint: disable=protected-access
 
 
 def test_create():
     adapter = SimpleA2CAgentAdapter()
-    model = adapter._create(model_id="test", observation_size=2, hidden_size=10, action_count=3)
+    model, model_user_data = adapter._create(
+        model_id="test",
+        environment_specs=EnvironmentSpecs(implementation="foo", num_input=2, num_action=3),
+        actor_network_hidden_size=10,
+        critic_network_hidden_size=12,
+    )
     assert model.model_id == "test"
     assert model.version_number == 1
     assert isinstance(model.actor_network, torch.nn.Module)
     assert isinstance(model.critic_network, torch.nn.Module)
+    assert model_user_data == {"environment_implementation": "foo", "num_input": 2, "num_action": 3}
 
 
 def test_save_and_load():
     adapter = SimpleA2CAgentAdapter()
-    model = adapter._create(model_id="test", observation_size=4, action_count=2)
+    environment_specs = EnvironmentSpecs(implementation="foo", num_input=4, num_action=3)
+    model, model_user_data = adapter._create(
+        model_id="test",
+        environment_specs=environment_specs,
+    )
 
     with io.BytesIO() as serialized_model_io:
-        adapter._save(model=model, model_data_f=serialized_model_io)
+        adapter._save(
+            model=model,
+            model_user_data=model_user_data,
+            model_data_f=serialized_model_io,
+            environment_specs=environment_specs,
+        )
         serialized_model_data = serialized_model_io.getvalue()
 
     deserialized_model = adapter._load(
-        model_id="test", version_number=2, version_user_data={}, model_data_f=io.BytesIO(serialized_model_data)
+        model_id="test",
+        version_number=2,
+        model_user_data=model_user_data,
+        version_user_data={},
+        model_data_f=io.BytesIO(serialized_model_data),
+        environment_specs=environment_specs,
     )
 
     assert deserialized_model.model_id == "test"

--- a/web_client/package-lock.json
+++ b/web_client/package-lock.json
@@ -15378,6 +15378,15 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -18449,6 +18458,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -22156,6 +22171,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.25",
@@ -27469,7 +27490,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -28060,7 +28085,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/web_client/package.json
+++ b/web_client/package.json
@@ -27,7 +27,9 @@
     "start": "npm run cogment_generate && react-scripts start",
     "build": "npm run cogment_generate && react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "npx prettier --check .",
+    "lint_fix": "npx prettier -w ."
   },
   "eslintConfig": {
     "extends": [

--- a/web_client/src/App.tsx
+++ b/web_client/src/App.tsx
@@ -138,19 +138,22 @@ function App() {
       if (!event.last) {
         const action = new data_pb.cogment_verse.AgentAction();
         let action_int = -1;
-        let keymap = undefined;
-        if (actorConfig.environmentSpecs.implementation) {
-          keymap = get_keymap(actorConfig.environmentSpecs.implementation);
-        }
 
-        if (keymap === undefined) {
-          console.log(`no keymap defined for actor config ${actorConfig}`);
-        } else {
-          for (let item of keymap.action_map) {
-            const keySet = new Set<string>(item.keys);
-            if (setIsEndOfArray(keySet, pressedKeys)) {
-              action_int = item.id;
-              break;
+        if (actorConfig.role === data_pb.cogment_verse.HumanRole.TEACHER) {
+          let keymap = undefined;
+          if (actorConfig.environmentSpecs.implementation) {
+            keymap = get_keymap(actorConfig.environmentSpecs.implementation);
+          }
+
+          if (keymap === undefined) {
+            console.log(`no keymap defined for actor config ${actorConfig}`);
+          } else {
+            for (let item of keymap.action_map) {
+              const keySet = new Set<string>(item.keys);
+              if (setIsEndOfArray(keySet, pressedKeys)) {
+                action_int = item.id;
+                break;
+              }
             }
           }
         }
@@ -191,7 +194,13 @@ function App() {
 
   useEffect(() => {
     if (trialJoined) {
-      setTrialStatus("trial joined");
+      if (actorConfig && actorConfig.role === data_pb.cogment_verse.HumanRole.TEACHER) {
+        setTrialStatus("trial joined as teacher");
+      } else if (actorConfig && actorConfig.role === data_pb.cogment_verse.HumanRole.OBSERVER) {
+        setTrialStatus("trial joined as observer");
+      } else {
+        setTrialStatus("trial joined (unknown role)");
+      }
       setCanStartTrial(false);
       if (actorConfig && actorConfig.environmentSpecs && actorConfig.environmentSpecs.implementation) {
         setEnvironmentImplementation(actorConfig.environmentSpecs.implementation);

--- a/web_client/src/App.tsx
+++ b/web_client/src/App.tsx
@@ -128,7 +128,13 @@ function App() {
   }, [event, actorConfig, trialJoined]);
 
   useEffect(() => {
-    if (trialJoined && actorConfig && actorConfig.environmentSpecs && event.observation && event.observation.pixelData) {
+    if (
+      trialJoined &&
+      actorConfig &&
+      actorConfig.environmentSpecs &&
+      event.observation &&
+      event.observation.pixelData
+    ) {
       if (!event.last) {
         const action = new data_pb.cogment_verse.AgentAction();
         let action_int = -1;

--- a/web_client/src/App.tsx
+++ b/web_client/src/App.tsx
@@ -77,7 +77,7 @@ function App() {
 
   type ObservationT = data_pb.cogment_verse.Observation;
   type ActionT = data_pb.cogment_verse.AgentAction;
-  type TeacherConfigT = data_pb.cogment_verse.TeacherConfig;
+  type HumanConfigT = data_pb.cogment_verse.HumanConfig;
 
   useEffect(() => {
     //const canvas = canvasRef.current;
@@ -95,7 +95,7 @@ function App() {
   const [event, joinTrial, _sendAction, reset, trialJoined, watchTrials, trialStateList, actorConfig] = useActions<
     ObservationT,
     ActionT,
-    TeacherConfigT
+    HumanConfigT
   >(
     cogSettings,
     "web_actor", // actor name
@@ -138,7 +138,10 @@ function App() {
       if (!event.last) {
         const action = new data_pb.cogment_verse.AgentAction();
         let action_int = -1;
-        const keymap = get_keymap(actorConfig.environmentSpecs.implementation);
+        let keymap = undefined;
+        if (actorConfig.environmentSpecs.implementation) {
+          keymap = get_keymap(actorConfig.environmentSpecs.implementation);
+        }
 
         if (keymap === undefined) {
           console.log(`no keymap defined for actor config ${actorConfig}`);
@@ -190,7 +193,7 @@ function App() {
     if (trialJoined) {
       setTrialStatus("trial joined");
       setCanStartTrial(false);
-      if (actorConfig && actorConfig.environmentSpecs) {
+      if (actorConfig && actorConfig.environmentSpecs && actorConfig.environmentSpecs.implementation) {
         setEnvironmentImplementation(actorConfig.environmentSpecs.implementation);
       }
     } else {

--- a/web_client/src/App.tsx
+++ b/web_client/src/App.tsx
@@ -77,7 +77,7 @@ function App() {
 
   type ObservationT = data_pb.cogment_verse.Observation;
   type ActionT = data_pb.cogment_verse.AgentAction;
-  type ConfigT = data_pb.cogment_verse.ActorConfig;
+  type TeacherConfigT = data_pb.cogment_verse.TeacherConfig;
 
   useEffect(() => {
     //const canvas = canvasRef.current;
@@ -95,7 +95,7 @@ function App() {
   const [event, joinTrial, _sendAction, reset, trialJoined, watchTrials, trialStateList, actorConfig] = useActions<
     ObservationT,
     ActionT,
-    ConfigT
+    TeacherConfigT
   >(
     cogSettings,
     "web_actor", // actor name
@@ -128,11 +128,11 @@ function App() {
   }, [event, actorConfig, trialJoined]);
 
   useEffect(() => {
-    if (trialJoined && actorConfig && event.observation && event.observation.pixelData) {
+    if (trialJoined && actorConfig && actorConfig.environmentSpecs && event.observation && event.observation.pixelData) {
       if (!event.last) {
         const action = new data_pb.cogment_verse.AgentAction();
         let action_int = -1;
-        const keymap = get_keymap(actorConfig.environmentImplementation);
+        const keymap = get_keymap(actorConfig.environmentSpecs.implementation);
 
         if (keymap === undefined) {
           console.log(`no keymap defined for actor config ${actorConfig}`);
@@ -184,8 +184,8 @@ function App() {
     if (trialJoined) {
       setTrialStatus("trial joined");
       setCanStartTrial(false);
-      if (actorConfig) {
-        setEnvironmentImplementation(actorConfig.environmentImplementation);
+      if (actorConfig && actorConfig.environmentSpecs) {
+        setEnvironmentImplementation(actorConfig.environmentSpecs.implementation);
       }
     } else {
       setTrialStatus("no trial running");


### PR DESCRIPTION
> _This PR is built upon #36 which should be integrated first_

closes #11 

Also:
- Introduce a `random` actor implementation. Only works with discrete action spaces for now
- Introduce the concept of `EnvironmentSpec` as a datastructure communicating the characteristics of an environment between runs and actors.
- Models are serialized alongside their environment specs to be easier to reload and check.
- Introduce a role for the human player, disable webclient controls when as `observer`