### PR TITLE
Update model registry to v0.6.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,19 +29,14 @@ services:
       - COGMENT_TRIAL_DATASTORE_LOG_LEVEL=info
 
   model_registry:
-    image: cogment/model-registry:v0.5.0
+    image: cogment/model-registry:v0.6.0
     restart: on-failure
     environment:
       - COGMENT_MODEL_REGISTRY_PORT=${COGMENT_VERSE_MODEL_REGISTRY_PORT}
       # Limit chunk size due to GRPC message size limit
       - COGMENT_MODEL_REGISTRY_SENT_MODEL_VERSION_DATA_CHUNK_SIZE=2097152
-      # Set memory cache maximum size to 1GB
-      - COGMENT_MODEL_REGISTRY_VERSION_CACHE_MAX_SIZE=1073741824
-      # Set memory cache expiration to 1 hour, can be set to any string
-      # that can be parsed by Go's time.ParseDuration
-      - COGMENT_MODEL_REGISTRY_VERSION_CACHE_EXPIRATION=1h
-      # Amount of model versions that are removed from the cache at once
-      - COGMENT_MODEL_REGISTRY_VERSION_CACHE_TO_PRUNE_COUNT=50
+      # Set maximum number of items for memory cache
+      - COGMENT_MODEL_REGISTRY_VERSION_CACHE_MAX_ITEMS=100
     volumes:
       - ./data/model-registry:/data
 


### PR DESCRIPTION
Update to latest model registry version. Fixes issue that caused long running jobs to eventually crash.