### PR TITLE
Pytorch multiproc fix

### DIFF
--- a/actors/simple_a2c.py
+++ b/actors/simple_a2c.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import logging
 
 import cogment

--- a/actors/simple_a2c.py
+++ b/actors/simple_a2c.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import logging
 
 import cogment
@@ -29,6 +28,7 @@ from cogment_verse.specs import (
 )
 from cogment_verse import Model
 
+torch.multiprocessing.set_sharing_strategy("file_system")
 
 log = logging.getLogger(__name__)
 

--- a/actors/simple_dqn.py
+++ b/actors/simple_dqn.py
@@ -17,10 +17,11 @@ import copy
 import time
 import json
 import math
+import numpy as np
 
 import cogment
 import torch
-import numpy as np
+
 
 from cogment_verse.specs import (
     AgentConfig,
@@ -39,6 +40,7 @@ from cogment_verse.specs import (
 
 from cogment_verse import Model, TorchReplayBuffer
 
+torch.multiprocessing.set_sharing_strategy("file_system")
 
 log = logging.getLogger(__name__)
 

--- a/actors/tutorial/tutorial_2.py
+++ b/actors/tutorial/tutorial_2.py
@@ -36,6 +36,8 @@ from cogment_verse.specs import (
     WEB_ACTOR_NAME,
 )
 
+torch.multiprocessing.set_sharing_strategy("file_system")
+
 log = logging.getLogger(__name__)
 
 

--- a/actors/tutorial/tutorial_3.py
+++ b/actors/tutorial/tutorial_3.py
@@ -39,6 +39,8 @@ from cogment_verse.specs import (
     WEB_ACTOR_NAME,
 )
 
+torch.multiprocessing.set_sharing_strategy("file_system")
+
 log = logging.getLogger(__name__)
 
 ############ TUTORIAL STEP 3 ############

--- a/actors/tutorial/tutorial_4.py
+++ b/actors/tutorial/tutorial_4.py
@@ -37,6 +37,8 @@ from cogment_verse.specs import (
     WEB_ACTOR_NAME,
 )
 
+torch.multiprocessing.set_sharing_strategy("file_system")
+
 log = logging.getLogger(__name__)
 
 

--- a/cogment_verse/replay_buffers/torch_replay_buffer.py
+++ b/cogment_verse/replay_buffers/torch_replay_buffer.py
@@ -15,6 +15,8 @@
 import numpy as np
 import torch
 
+torch.multiprocessing.set_sharing_strategy("file_system")
+
 
 class TorchReplayBufferSample:
     def __init__(self, observation, next_observation, action, reward, done):

--- a/config/experiment/simple_a2c/cartpole.yaml
+++ b/config/experiment/simple_a2c/cartpole.yaml
@@ -2,7 +2,7 @@
 defaults:
   - override /services/actor:
       - simple_a2c
-  - override /run: simple_a2c
+  - override /run: headless_play
   - override /services/environment: cartpole
 
 run:

--- a/main.py
+++ b/main.py
@@ -14,12 +14,11 @@
 
 import logging
 import os
+import multiprocessing as mp
 
 import hydra
 
 import cogment_verse
-import torch.multiprocessing as mp
-mp.set_sharing_strategy('file_system')
 
 log = logging.getLogger(__name__)
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ import os
 import hydra
 
 import cogment_verse
+import torch.multiprocessing as mp
+mp.set_sharing_strategy('file_system')
 
 log = logging.getLogger(__name__)
 
@@ -32,4 +34,5 @@ def main(cfg):
 
 
 if __name__ == "__main__":
+    mp.set_start_method("spawn")
     main()


### PR DESCRIPTION
I tried updating to pytorch 1.12 and it did not fix the problem.  It is possible to put the `torch.multiprocessing.set_sharing_strategy("file_system")` line just once in the torch replay buffer as that is always loaded in.  However if the replay buffer is not needed in the future and that import is not longer always there other multiprocesses that use pytorch will likely break.