### PR TITLE
Fix DQN model update frequency

### DIFF
--- a/actors/simple_dqn.py
+++ b/actors/simple_dqn.py
@@ -122,6 +122,7 @@ class SimpleDQNModel(Model):
 class SimpleDQNActor:
     def __init__(self, _cfg):
         self._dtype = torch.float
+        self.samples_since_update = 0
 
     def get_actor_classes(self):
         return [PLAYER_ACTOR_CLASS]
@@ -153,14 +154,16 @@ class SimpleDQNActor:
                     continue
 
                 if (
-                    config.model_version == -1
-                    and config.model_update_frequency > 0
-                    and actor_session.get_tick_id() % config.model_update_frequency == 0
+                    config.model_update_frequency > 0
+                    and self.samples_since_update > 0
+                    and self.samples_since_update % config.model_update_frequency == 0
                 ):
                     model, _, _ = await actor_session.model_registry.retrieve_version(
                         SimpleDQNModel, config.model_id, config.model_version
                     )
                     model.network.eval()
+                    self.samples_since_update =0
+
                 if rng.random() < model.epsilon:
                     action = action_space.sample(mask=observation.action_mask)
                 else:
@@ -176,6 +179,7 @@ class SimpleDQNActor:
                     discrete_action_tensor = torch.argmax(action_probs)
                     action = action_space.create(value=discrete_action_tensor.item())
 
+                self.samples_since_update += 1
                 actor_session.do_action(action_space.serialize(action))
 
 

--- a/config/experiment/simple_dqn/cartpole.yaml
+++ b/config/experiment/simple_dqn/cartpole.yaml
@@ -6,18 +6,28 @@ defaults:
 run:
   class_name: actors.simple_dqn.SimpleDQNTraining
   seed: 618
-  num_trials: 10000
-  num_parallel_trials: 10
-  learning_starts: ${run.batch_size}
+
+  # Archiving
+  archive_model: True
+  archive_frequency: 20000                    # Unit: steps
+
+  # Training Params
+  num_trials: 10000                           # Unit: trials
+  num_parallel_trials: 10                     # Unit: trials
+  learning_starts: ${run.batch_size}          # Unit: steps
+  target_update_frequency: 2000               # Unit: steps
+  buffer_size: 10000                          # Unit: steps
+  train_frequency: 10                         # Unit: steps
+  model_update_frequency: 10                  # Unit: steps
+
+  # Network Params
+  value_network:
+    num_hidden_nodes: [128, 64]
   learning_rate: 0.000125
   discount_factor: 0.95
-  target_update_frequency: 2000
   batch_size: 64
-  buffer_size: 10000
   epsilon_schedule_start: 1
   epsilon_schedule_end: 0.05
   epsilon_schedule_duration_ratio: 0.75
-  train_frequency: 10
-  model_update_frequency: 10
-  value_network:
-    num_hidden_nodes: [128, 64]
+  
+  

--- a/config/experiment/simple_dqn/connect_four.yaml
+++ b/config/experiment/simple_dqn/connect_four.yaml
@@ -7,20 +7,30 @@ defaults:
 run:
   class_name: actors.simple_dqn.SimpleDQNSelfPlayTraining
   seed: 618
+
+  # Archiving
+  archive_model: True
+  archive_frequency: 20000                  # Unit: steps
+
+  # Training Params
   num_epochs: 75
-  epoch_num_training_trials: 200
-  epoch_num_validation_trials: 20
-  num_parallel_trials: 10
-  learning_starts: ${run.batch_size}
+  epoch_num_training_trials: 200            # Unit: trials
+  epoch_num_validation_trials: 20           # Unit: trials
+  num_parallel_trials: 10                   # Unit: trials
+  learning_starts: ${run.batch_size}        # Unit: steps
+  target_update_frequency: 4000             # Unit: steps
+  buffer_size: 10000                        # Unit: steps
+  train_frequency: 10                       # Unit: steps
+  model_update_frequency: 10                # Unit: steps
+
+  # Network Params
+  value_network:
+    num_hidden_nodes: [128, 64]
   learning_rate: 0.0005
   discount_factor: 0.99
-  target_update_frequency: 4000
   batch_size: 256
-  buffer_size: 10000
   epsilon_schedule_start: 1
   epsilon_schedule_end: 0.05
   epsilon_schedule_duration_ratio: 0.75
-  train_frequency: 10
-  model_update_frequency: 10
-  value_network:
-    num_hidden_nodes: [128, 64]
+  
+  


### PR DESCRIPTION
### Context

The `actor_session.get_tick_id()` resets back to `0` after every trial.
For environments where the number of steps is lower than the `config.model_update_frequency`, the model update condition will be skipped. 

### Solution
Add a sample counter for the Actor class.

### Other changes
Improve readability of dqn configs.