### PR TITLE
Bugfix: Reduce Model Registry GRPC byte size limit

### DIFF
--- a/cogment_verse/model_registry.py
+++ b/cogment_verse/model_registry.py
@@ -172,7 +172,7 @@ class ModelRegistry:
 
                 yield CreateVersionRequestChunk(header=CreateVersionRequestChunk.Header(version_info=version_info))
 
-                chunksize = GRPC_BYTE_SIZE_LIMIT  # 2MB to keep under well under the GRPC 4MB limit
+                chunksize = GRPC_BYTE_SIZE_LIMIT / 2  # 2MB to keep under well under the GRPC 4MB limit
                 sent_chunk_num = 0
                 while version_data:
                     yield CreateVersionRequestChunk(

--- a/cogment_verse/model_registry.py
+++ b/cogment_verse/model_registry.py
@@ -17,6 +17,7 @@ import asyncio
 import copy
 import io
 import logging
+import math
 import time
 from urllib.parse import urlparse
 
@@ -172,7 +173,7 @@ class ModelRegistry:
 
                 yield CreateVersionRequestChunk(header=CreateVersionRequestChunk.Header(version_info=version_info))
 
-                chunksize = GRPC_BYTE_SIZE_LIMIT / 2  # 2MB to keep under well under the GRPC 4MB limit
+                chunksize = math.trunc(GRPC_BYTE_SIZE_LIMIT / 2)  # 2MB to keep under well under the GRPC 4MB limit
                 sent_chunk_num = 0
                 while version_data:
                     yield CreateVersionRequestChunk(


### PR DESCRIPTION
## Context
In a previous PR, I unintentionally increase the cogment-verse model registry's grpc byte size limit from 2MB (safe limit) to the actual limit of 4MB. This caused some grpc errors: StatusCode.RESOURCE_EXHAUSTED when publishing some models.

This PR restores the original value.

## Solution
Divide the limit again by 2.

## Testing
I will add a smoke test in the Model Registry [PR](https://github.com/cogment/cogment-verse/pull/144) to test publishing a larger model, to make sure this does not happen again!