### PR TITLE
156 Migrate to new gym step API

### DIFF
--- a/actors/ppo.py
+++ b/actors/ppo.py
@@ -330,7 +330,7 @@ class PPOActor:
             serialized_model = await actor_session.model_registry.retrieve_model(
                 config.model_id, config.model_iteration
             )
-            model = PPOModel.deserialize_model(serialized_model, config.model_id, config.model_iteration)
+            model = PPOModel.deserialize_model(serialized_model)
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/ppo_atari_pz.py
+++ b/actors/ppo_atari_pz.py
@@ -205,7 +205,7 @@ class PPOActor:
             serialized_model = await actor_session.model_registry.retrieve_model(
                 config.model_id, config.model_iteration
             )
-            model = PPOModel.deserialize_model(serialized_model, config.model_id, config.model_iteration)
+            model = PPOModel.deserialize_model(serialized_model)
 
         log.info(f"Actor - retreved model number: {model.iteration}")
         obs_shape = model.input_shape[::-1]

--- a/actors/simple_a2c.py
+++ b/actors/simple_a2c.py
@@ -148,7 +148,7 @@ class SimpleA2CActor:
             serialized_model = await actor_session.model_registry.retrieve_model(
                 config.model_id, config.model_iteration
             )
-            model = SimpleA2CModel.deserialize_model(serialized_model, config.model_id, config.model_iteration)
+            model = SimpleA2CModel.deserialize_model(serialized_model)
 
         model.actor_network.eval()
         model.critic_network.eval()

--- a/actors/simple_dqn.py
+++ b/actors/simple_dqn.py
@@ -158,7 +158,7 @@ class SimpleDQNActor:
             serialized_model = await actor_session.model_registry.retrieve_model(
                 config.model_id, config.model_iteration
             )
-            model = SimpleDQNModel.deserialize_model(serialized_model, config.model_id, config.model_iteration)
+            model = SimpleDQNModel.deserialize_model(serialized_model)
 
         model.network.eval()
 
@@ -185,9 +185,7 @@ class SimpleDQNActor:
                         serialized_model = await actor_session.model_registry.retrieve_model(
                             config.model_id, config.model_iteration
                         )
-                        model = SimpleDQNModel.deserialize_model(
-                            serialized_model, config.model_id, config.model_iteration
-                        )
+                        model = SimpleDQNModel.deserialize_model(serialized_model)
 
                     model.network.eval()
 

--- a/actors/td3.py
+++ b/actors/td3.py
@@ -213,7 +213,7 @@ class TD3Actor:
             serialized_model = await actor_session.model_registry.retrieve_model(
                 config.model_id, config.model_iteration
             )
-            model = TD3Model.deserialize_model(serialized_model, config.model_id, config.model_iteration)
+            model = TD3Model.deserialize_model(serialized_model)
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/tutorial/tutorial_3.py
+++ b/actors/tutorial/tutorial_3.py
@@ -147,7 +147,7 @@ class SimpleBCActor:
             serialized_model = await actor_session.model_registry.retrieve_model(
                 config.model_id, config.model_iteration
             )
-            model = SimpleBCModel.deserialize_model(serialized_model, config.model_id, config.model_iteration)
+            model = SimpleBCModel.deserialize_model(serialized_model)
 
         log.info(f"Starting trial with model v{model.iteration}")
 

--- a/actors/tutorial/tutorial_4.py
+++ b/actors/tutorial/tutorial_4.py
@@ -143,7 +143,7 @@ class SimpleBCActor:
             serialized_model = await actor_session.model_registry.retrieve_model(
                 config.model_id, config.model_iteration
             )
-            model = SimpleBCModel.deserialize_model(serialized_model, config.model_id, config.model_iteration)
+            model = SimpleBCModel.deserialize_model(serialized_model)
 
         log.info(f"Starting trial with model v{model.iteration}")
 

--- a/environments/gym_adapter.py
+++ b/environments/gym_adapter.py
@@ -29,7 +29,7 @@ class Environment:
     def __init__(self, cfg):
         self.gym_env_name = cfg.env_name
 
-        gym_env = gym.make(self.gym_env_name)
+        gym_env = gym.make(self.gym_env_name, new_step_api=True)
 
         self.env_specs = EnvironmentSpecs.create_homogeneous(
             num_players=1,
@@ -67,7 +67,7 @@ class Environment:
 
         session_cfg = environment_session.config
 
-        gym_env = gym.make(self.gym_env_name, render_mode="single_rgb_array" if session_cfg.render else None)
+        gym_env = gym.make(self.gym_env_name, render_mode="single_rgb_array" if session_cfg.render else None, new_step_api=True)
         observation_space = self.env_specs.get_observation_space(session_cfg.render_width)
         action_space = self.env_specs.get_action_space()
 
@@ -100,7 +100,7 @@ class Environment:
                 if isinstance(gym_env.action_space, gym.spaces.Box):
                     action_value = np.clip(action_value, gym_env.action_space.low, gym_env.action_space.high)
 
-                gym_observation, reward, done, _info = gym_env.step(action_value)
+                gym_observation, reward, terminated, truncated, _info = gym_env.step(action_value)
 
                 observation = observation_space.create(
                     value=gym_observation,
@@ -117,7 +117,7 @@ class Environment:
                         to=[player_actor_name],
                     )
 
-                if done:
+                if terminated or truncated:
                     # The trial ended
                     environment_session.end(observations)
                 elif event.type != cogment.EventType.ACTIVE:

--- a/environments/gym_adapter.py
+++ b/environments/gym_adapter.py
@@ -67,7 +67,9 @@ class Environment:
 
         session_cfg = environment_session.config
 
-        gym_env = gym.make(self.gym_env_name, render_mode="single_rgb_array" if session_cfg.render else None, new_step_api=True)
+        gym_env = gym.make(
+            self.gym_env_name, render_mode="single_rgb_array" if session_cfg.render else None, new_step_api=True
+        )
         observation_space = self.env_specs.get_observation_space(session_cfg.render_width)
         action_space = self.env_specs.get_action_space()
 

--- a/environments/isaac_adapter.py
+++ b/environments/isaac_adapter.py
@@ -35,7 +35,6 @@ class Environment:
         self.gym_env_name = cfg.env_name
         print("self.gym_env_name = ", self.gym_env_name)
 
-        # gym_env = gym.make(self.gym_env_name)
         self.gym_env = isaacgymenvs.make(
             seed=0,
             task=self.gym_env_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==67.2", "wheel"]
+requires = ["setuptools<67.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools==67.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/tests/functional/test_config/simple_dqn/observe_connect_four_specific_iteration_ft.yaml
+++ b/tests/functional/test_config/simple_dqn/observe_connect_four_specific_iteration_ft.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+defaults:
+  - override /services/actor:
+      - simple_dqn
+  - override /services/environment: connect_four
+  - override /run: observe
+  - override /services/experiment_tracker@run.experiment_tracker: simple
+
+run:
+  observer: False
+  num_trials: 1
+  players:
+    - name: player_1
+      implementation: actors.simple_dqn.SimpleDQNActor
+      agent_config:
+        model_id: connect_four_self_training_model
+        model_iteration: 2
+    - name: player_2
+      implementation: actors.simple_dqn.SimpleDQNActor
+      agent_config:
+        model_id: ${run.players.0.agent_config.model_id}
+        model_iteration: ${run.players.0.agent_config.model_iteration}

--- a/tests/functional/test_experiments.py
+++ b/tests/functional/test_experiments.py
@@ -110,6 +110,19 @@ def test__model_registry(_prepare_config):
     proc.communicate()
     assert proc.returncode == 0
 
+    # Using the model iteration -1
+    proc = subprocess.Popen(
+        args=[
+            sys.executable,
+            "-m",
+            "tests.functional.test_experiments",
+            "+experiment=simple_dqn/observe_connect_four_specific_iteration_ft",
+        ]
+    )
+    proc.communicate()
+    assert proc.returncode == 0
+
+    # Using a specific model iteration number
     proc = subprocess.Popen(
         args=[
             sys.executable,

--- a/tests/functional/test_experiments.py
+++ b/tests/functional/test_experiments.py
@@ -110,7 +110,7 @@ def test__model_registry(_prepare_config):
     proc.communicate()
     assert proc.returncode == 0
 
-    # Using the model iteration -1
+    # Using a specific model iteration number
     proc = subprocess.Popen(
         args=[
             sys.executable,
@@ -122,7 +122,7 @@ def test__model_registry(_prepare_config):
     proc.communicate()
     assert proc.returncode == 0
 
-    # Using a specific model iteration number
+    # Using the model iteration -1
     proc = subprocess.Popen(
         args=[
             sys.executable,

--- a/tests/test_spaces_serialization.py
+++ b/tests/test_spaces_serialization.py
@@ -45,7 +45,7 @@ def test_serialize_connect4_observation_space():
 
 
 def test_serialize_cartpole_observation_space():
-    env = gym.make("CartPole-v1")
+    env = gym.make("CartPole-v1", new_step_api=True)
 
     gym_space = env.observation_space
 


### PR DESCRIPTION
### Context
Cogment-verse has an annoying amount of warnings coming from third party libraries when launching an experiment. This PR removes them.

### Solution
1. Moving to the new gym step API for creating the env because a temporary wrapper support is provided for the old code and it will cease to be backward compatible very soon.

The main ramifications are that the `step` function output will go from 4 output:
```
next_state, reward, done , info = env.step(action)
```
to 5, by splitting the `done` flag into the flags terminated and truncated.
```
next_state, reward, terminated, truncated , info = env.step(action)
```
Truncated is meant for episodes that were cancelled for a exceeding a maximum number of steps, a timeout or failed execution. On the other hand, terminated is for eposides that ended under normal environment conditions (game won, game lost, etc). For our use of the `done` flag, we can use `terminated or trunctated` as a replacement.

2. Fix setuptools version `<67.3.0` because version `67.3.0` introduced a new way to declare namespaces that is not implemented in most libraries yet and raises an annoying warning for multiple libraries.
[Example git issue](https://github.com/matplotlib/matplotlib/issues/25244).


### Other changes
Bug fix for `deserialize_model` function. Extra arguments were not removed for cases where `model_iteration` is not `-1`. Bugfix for PR https://github.com/cogment/cogment-verse/pull/144


closes #156 