### PR TITLE
Fix model iteration during deserialization

### DIFF
--- a/actors/ppo.py
+++ b/actors/ppo.py
@@ -248,6 +248,10 @@ class PPOModel(Model):
         if self._state_norm:
             self.state_normalization = Normalization(dtype=self._dtype, nums=self._num_input)
 
+    def eval(self) -> None:
+        self.policy_network.eval()
+        self.value_network.eval()
+
     def get_model_user_data(self) -> dict:
         """Get user model"""
         return {
@@ -320,8 +324,7 @@ class PPOActor:
 
         # Get model
         model = await PPOModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
-        model.policy_network.eval()
-        model.value_network.eval()
+        model.eval()
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/ppo.py
+++ b/actors/ppo.py
@@ -323,7 +323,7 @@ class PPOActor:
         assert config.environment_specs.num_players == 1
 
         # Get model
-        model = await PPOModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await PPOModel.retrieve_model(actor_session.model_registry, config.model_id, config.model_iteration)
         model.eval()
 
         async for event in actor_session.all_events():

--- a/actors/ppo.py
+++ b/actors/ppo.py
@@ -252,7 +252,6 @@ class PPOModel(Model):
         """Get user model"""
         return {
             "model_id": self.model_id,
-            "iteration": self.iteration,
             "environment_implementation": self._environment_implementation,
             "num_input": self._num_input,
             "num_output": self._num_output,
@@ -282,7 +281,6 @@ class PPOModel(Model):
 
         model = cls(
             model_id=model_user_data["model_id"],
-            iteration=model_user_data["iteration"],
             environment_implementation=model_user_data["environment_implementation"],
             num_input=int(model_user_data["num_input"]),
             num_output=int(model_user_data["num_output"]),
@@ -321,16 +319,9 @@ class PPOActor:
         assert config.environment_specs.num_players == 1
 
         # Get model
-        if config.model_iteration == -1:
-            latest_model = await actor_session.model_registry.track_latest_model(
-                name=config.model_id, deserialize_func=PPOModel.deserialize_model
-            )
-            model, _ = await latest_model.get()
-        else:
-            serialized_model = await actor_session.model_registry.retrieve_model(
-                config.model_id, config.model_iteration
-            )
-            model = PPOModel.deserialize_model(serialized_model)
+        model = await PPOModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model.policy_network.eval()
+        model.value_network.eval()
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/ppo_atari_pz.py
+++ b/actors/ppo_atari_pz.py
@@ -194,7 +194,7 @@ class PPOActor:
         action_space = environment_specs.get_action_space(seed=config.seed)
 
         # Get model
-        model = await PPOModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await PPOModel.retrieve_model(actor_session.model_registry, config.model_id, config.model_iteration)
         model.network.eval()
 
         log.info(f"Actor - retreved model number: {model.iteration}")

--- a/actors/sac.py
+++ b/actors/sac.py
@@ -285,7 +285,7 @@ class SACActor:
         bias = torch.tensor((action_max + action_min) / 2.0, dtype=self._dtype)
 
         # Get model
-        model = await SACModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await SACModel.retrieve_model(actor_session.model_registry, config.model_id, config.model_iteration)
         model.eval()
 
         async for event in actor_session.all_events():

--- a/actors/sac.py
+++ b/actors/sac.py
@@ -153,6 +153,13 @@ class SACModel(Model):
         else:
             self._device = torch.device("cpu")
 
+    def eval(self) -> None:
+        self.policy_network.eval()
+        self.value_network_1.eval()
+        self.value_network_2.eval()
+        self.target_network_1.eval()
+        self.target_network_2.eval()
+
     def get_model_user_data(self) -> dict:
         """Get user model"""
         return {
@@ -279,11 +286,7 @@ class SACActor:
 
         # Get model
         model = await SACModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
-        model.policy_network.eval()
-        model.value_network_1.eval()
-        model.value_network_2.eval()
-        model.target_network_1.eval()
-        model.target_network_2.eval()
+        model.eval()
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/simple_a2c.py
+++ b/actors/simple_a2c.py
@@ -141,7 +141,9 @@ class SimpleA2CActor:
         action_space = environment_specs.get_action_space(seed=config.seed)
 
         # Get model
-        model = await SimpleA2CModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await SimpleA2CModel.retrieve_model(
+            actor_session.model_registry, config.model_id, config.model_iteration
+        )
         model.eval()
 
         async for event in actor_session.all_events():

--- a/actors/simple_a2c.py
+++ b/actors/simple_a2c.py
@@ -77,7 +77,6 @@ class SimpleA2CModel(Model):
     def get_model_user_data(self):
         return {
             "model_id": self.model_id,
-            "iteration": self.iteration,
             "environment_implementation": self._environment_implementation,
             "num_input": self._num_input,
             "num_output": self._num_output,
@@ -107,7 +106,6 @@ class SimpleA2CModel(Model):
 
         model = cls(
             model_id=model_user_data["model_id"],
-            iteration=model_user_data["iteration"],
             environment_implementation=model_user_data["environment_implementation"],
             num_input=int(model_user_data["num_input"]),
             num_output=int(model_user_data["num_output"]),
@@ -139,17 +137,7 @@ class SimpleA2CActor:
         action_space = environment_specs.get_action_space(seed=config.seed)
 
         # Get model
-        if config.model_iteration == -1:
-            latest_model = await actor_session.model_registry.track_latest_model(
-                name=config.model_id, deserialize_func=SimpleA2CModel.deserialize_model
-            )
-            model, _ = await latest_model.get()
-        else:
-            serialized_model = await actor_session.model_registry.retrieve_model(
-                config.model_id, config.model_iteration
-            )
-            model = SimpleA2CModel.deserialize_model(serialized_model)
-
+        model = await SimpleA2CModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
         model.actor_network.eval()
         model.critic_network.eval()
 

--- a/actors/simple_a2c.py
+++ b/actors/simple_a2c.py
@@ -74,6 +74,10 @@ class SimpleA2CModel(Model):
         self.epoch_idx = 0
         self.total_samples = 0
 
+    def eval(self) -> None:
+        self.actor_network.eval()
+        self.critic_network.eval()
+
     def get_model_user_data(self):
         return {
             "model_id": self.model_id,
@@ -138,8 +142,7 @@ class SimpleA2CActor:
 
         # Get model
         model = await SimpleA2CModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
-        model.actor_network.eval()
-        model.critic_network.eval()
+        model.eval()
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/simple_dqn.py
+++ b/actors/simple_dqn.py
@@ -95,7 +95,6 @@ class SimpleDQNModel(Model):
 
     @staticmethod
     def serialize_model(model) -> bytes:
-        print("")
         stream = io.BytesIO()
         torch.save(
             (

--- a/actors/simple_dqn.py
+++ b/actors/simple_dqn.py
@@ -147,7 +147,9 @@ class SimpleDQNActor:
         assert isinstance(action_space.gym_space, Discrete)
 
         # Get model
-        model = await SimpleDQNModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await SimpleDQNModel.retrieve_model(
+            actor_session.model_registry, config.model_id, config.model_iteration
+        )
         model.network.eval()
 
         async for event in actor_session.all_events():
@@ -164,7 +166,9 @@ class SimpleDQNActor:
                     and actor_session.get_tick_id() % config.model_update_frequency == 0
                 ):
                     # Get model
-                    model = await SimpleDQNModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+                    model = await SimpleDQNModel.retrieve_model(
+                        actor_session.model_registry, config.model_id, config.model_iteration
+                    )
                     model.network.eval()
 
                 if rng.random() < model.epsilon:

--- a/actors/simple_dqn.py
+++ b/actors/simple_dqn.py
@@ -163,6 +163,7 @@ class SimpleDQNActor:
                     and config.model_update_frequency > 0
                     and actor_session.get_tick_id() % config.model_update_frequency == 0
                 ):
+                    # Get model
                     model = await SimpleDQNModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
                     model.network.eval()
 

--- a/actors/simple_dqn.py
+++ b/actors/simple_dqn.py
@@ -279,13 +279,11 @@ class SimpleDQNTraining:
             dtype=self._dtype,
         )
 
-        print(f"Before serializing model iteration: {model.iteration}")
         serialized_model = SimpleDQNModel.serialize_model(model)
         iteration_info = await run_session.model_registry.publish_model(
             name=model_id,
             model=serialized_model,
         )
-        print(f"after publising, iteration_info: {iteration_info.iteration}")
 
         run_session.log_params(
             self._cfg,
@@ -404,7 +402,6 @@ class SimpleDQNTraining:
                     name=model_id,
                     model=serialized_model,
                 )
-                print(f"MODEL TRAINED: {iteration_info}")
 
                 if step_idx % 100 == 0:
                     end_time = time.time()

--- a/actors/td3.py
+++ b/actors/td3.py
@@ -121,6 +121,12 @@ class TD3Model(Model):
         self.epoch_idx = 0
         self.total_samples = 0
 
+    def eval(self) -> None:
+        self.actor.eval()
+        self.actor_target.eval()
+        self.critic.eval()
+        self.critic_target.eval()
+
     def get_model_user_data(self):
         return {
             "model_id": self.model_id,
@@ -203,10 +209,7 @@ class TD3Actor:
 
         # Get model
         model = await TD3Model.retrieve_model(actor_session, config.model_id, config.model_iteration)
-        model.actor.eval()
-        model.actor_target.eval()
-        model.critic.eval()
-        model.critic_target.eval()
+        model.eval()
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/td3.py
+++ b/actors/td3.py
@@ -208,7 +208,7 @@ class TD3Actor:
         assert isinstance(action_space.gym_space, Box)
 
         # Get model
-        model = await TD3Model.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await TD3Model.retrieve_model(actor_session.model_registry, config.model_id, config.model_iteration)
         model.eval()
 
         async for event in actor_session.all_events():

--- a/actors/td3.py
+++ b/actors/td3.py
@@ -124,7 +124,6 @@ class TD3Model(Model):
     def get_model_user_data(self):
         return {
             "model_id": self.model_id,
-            "iteration": self.iteration,
             "environment_implementation": self._environment_implementation,
             "num_input": self._num_input,
             "num_output": self._num_output,
@@ -165,7 +164,6 @@ class TD3Model(Model):
 
         model = cls(
             model_id=model_user_data["model_id"],
-            iteration=model_user_data["iteration"],
             environment_implementation=model_user_data["environment_implementation"],
             num_input=int(model_user_data["num_input"]),
             num_output=int(model_user_data["num_output"]),
@@ -204,16 +202,11 @@ class TD3Actor:
         assert isinstance(action_space.gym_space, Box)
 
         # Get model
-        if config.model_iteration == -1:
-            latest_model = await actor_session.model_registry.track_latest_model(
-                name=config.model_id, deserialize_func=TD3Model.deserialize_model
-            )
-            model, _ = await latest_model.get()
-        else:
-            serialized_model = await actor_session.model_registry.retrieve_model(
-                config.model_id, config.model_iteration
-            )
-            model = TD3Model.deserialize_model(serialized_model)
+        model = await TD3Model.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model.actor.eval()
+        model.actor_target.eval()
+        model.critic.eval()
+        model.critic_target.eval()
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/tutorial/tutorial_3.py
+++ b/actors/tutorial/tutorial_3.py
@@ -75,7 +75,6 @@ class SimpleBCModel(Model):
     def get_model_user_data(self):
         return {
             "model_id": self.model_id,
-            "iteration": self.iteration,
             "environment_implementation": self._environment_implementation,
             "num_input": self._num_input,
             "num_output": self._num_output,
@@ -102,7 +101,6 @@ class SimpleBCModel(Model):
 
         model = SimpleBCModel(
             model_id=model_user_data["model_id"],
-            iteration=model_user_data["iteration"],
             environment_implementation=model_user_data["environment_implementation"],
             num_input=int(model_user_data["num_input"]),
             num_output=int(model_user_data["num_output"]),
@@ -138,20 +136,11 @@ class SimpleBCActor:
         observation_space = environment_specs.get_observation_space()
 
         # Get model
-        if config.model_iteration == -1:
-            latest_model = await actor_session.model_registry.track_latest_model(
-                name=config.model_id, deserialize_func=SimpleBCModel.deserialize_model
-            )
-            model, _ = await latest_model.get()
-        else:
-            serialized_model = await actor_session.model_registry.retrieve_model(
-                config.model_id, config.model_iteration
-            )
-            model = SimpleBCModel.deserialize_model(serialized_model)
+        model = await SimpleBCModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model.policy_network.eval()
 
         log.info(f"Starting trial with model v{model.iteration}")
 
-        model.policy_network.eval()
         #########################################
 
         async for event in actor_session.all_events():

--- a/actors/tutorial/tutorial_3.py
+++ b/actors/tutorial/tutorial_3.py
@@ -136,7 +136,9 @@ class SimpleBCActor:
         observation_space = environment_specs.get_observation_space()
 
         # Get model
-        model = await SimpleBCModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await SimpleBCModel.retrieve_model(
+            actor_session.model_registry, config.model_id, config.model_iteration
+        )
         model.policy_network.eval()
 
         log.info(f"Starting trial with model v{model.iteration}")

--- a/actors/tutorial/tutorial_4.py
+++ b/actors/tutorial/tutorial_4.py
@@ -77,7 +77,6 @@ class SimpleBCModel(Model):
     def get_model_user_data(self):
         return {
             "model_id": self.model_id,
-            "iteration": self.iteration,
             "environment_implementation": self._environment_implementation,
             "num_input": self._num_input,
             "num_output": self._num_output,
@@ -104,7 +103,6 @@ class SimpleBCModel(Model):
 
         model = SimpleBCModel(
             model_id=model_user_data["model_id"],
-            iteration=model_user_data["iteration"],
             environment_implementation=model_user_data["environment_implementation"],
             num_input=int(model_user_data["num_input"]),
             num_output=int(model_user_data["num_output"]),
@@ -134,20 +132,10 @@ class SimpleBCActor:
         action_space = environment_specs.get_action_space(seed=config.seed)
 
         # Get model
-        if config.model_iteration == -1:
-            latest_model = await actor_session.model_registry.track_latest_model(
-                name=config.model_id, deserialize_func=SimpleBCModel.deserialize_model
-            )
-            model, _ = await latest_model.get()
-        else:
-            serialized_model = await actor_session.model_registry.retrieve_model(
-                config.model_id, config.model_iteration
-            )
-            model = SimpleBCModel.deserialize_model(serialized_model)
+        model = await SimpleBCModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model.policy_network.eval()
 
         log.info(f"Starting trial with model v{model.iteration}")
-
-        model.policy_network.eval()
 
         async for event in actor_session.all_events():
             if event.observation and event.type == cogment.EventType.ACTIVE:

--- a/actors/tutorial/tutorial_4.py
+++ b/actors/tutorial/tutorial_4.py
@@ -132,7 +132,9 @@ class SimpleBCActor:
         action_space = environment_specs.get_action_space(seed=config.seed)
 
         # Get model
-        model = await SimpleBCModel.retrieve_model(actor_session, config.model_id, config.model_iteration)
+        model = await SimpleBCModel.retrieve_model(
+            actor_session.model_registry, config.model_id, config.model_iteration
+        )
         model.policy_network.eval()
 
         log.info(f"Starting trial with model v{model.iteration}")

--- a/cogment_verse/model.py
+++ b/cogment_verse/model.py
@@ -14,6 +14,8 @@
 
 # pylint: disable=broad-except
 
+from __future__ import annotations
+
 import abc
 
 
@@ -52,3 +54,28 @@ class Model:
         Returns:
             model: the deserialized model
         """
+
+    @classmethod
+    async def retrieve_model(cls, actor_session, model_id, iteration) -> Model:
+        """
+        Retrieve and deserialize a specific or latest model iteration from the model registry.
+        If the configuration is set to retrieve iteration -1, the latest model is tracked.
+        Otherwise, it retrieves the specific model iteration.
+        Args:
+            actor_session: class representing the session of an actor for a trial
+            model_id: model id to retrieve
+            iteration: model iteration to retrieve
+        Returns:
+            model: the deserialized model
+        """
+        if iteration == -1:
+            latest_model = await actor_session.model_registry.track_latest_model(
+                name=model_id, deserialize_func=cls.deserialize_model
+            )
+            model, iteration_info = await latest_model.get()
+        else:
+            serialized_model = await actor_session.model_registry.retrieve_model(model_id, iteration)
+            model = cls.deserialize_model(serialized_model)
+            iteration_info = await actor_session.model_registry.get_iteration_info(model_id, iteration)
+        model.iteration = iteration_info.iteration
+        return model

--- a/cogment_verse/model.py
+++ b/cogment_verse/model.py
@@ -56,26 +56,26 @@ class Model:
         """
 
     @classmethod
-    async def retrieve_model(cls, actor_session, model_id, iteration) -> Model:
+    async def retrieve_model(cls, model_registry, model_id, iteration) -> Model:
         """
         Retrieve and deserialize a specific or latest model iteration from the model registry.
         If the configuration is set to retrieve iteration -1, the latest model is tracked.
         Otherwise, it retrieves the specific model iteration.
         Args:
-            actor_session: class representing the session of an actor for a trial
+            model_registry: model registry
             model_id: model id to retrieve
             iteration: model iteration to retrieve
         Returns:
             model: the deserialized model
         """
         if iteration == -1:
-            latest_model = await actor_session.model_registry.track_latest_model(
+            latest_model = await model_registry.track_latest_model(
                 name=model_id, deserialize_func=cls.deserialize_model
             )
             model, iteration_info = await latest_model.get()
         else:
-            serialized_model = await actor_session.model_registry.retrieve_model(model_id, iteration)
+            serialized_model = await model_registry.retrieve_model(model_id, iteration)
             model = cls.deserialize_model(serialized_model)
-            iteration_info = await actor_session.model_registry.get_iteration_info(model_id, iteration)
+            iteration_info = await model_registry.get_iteration_info(model_id, iteration)
         model.iteration = iteration_info.iteration
         return model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cogment[generate]==2.7.0
+cogment[generate]==2.7.1
 grpcio==1.43.0
 hydra-core==1.3.2
 mlflow==2.2.2


### PR DESCRIPTION
### Bug:
The current model iteration number was serialized with the model, then put back into the `Model` instance during deserialization. This way, the proper model iteration is retrieved from the model registry, but the model iteration was never incremented.

### Fix:
Remove the model iteration from the serialized `model_user_data`. Instead, retrieve the model iteration info from the model_registry and set it in the model instance.

Moved the model retrieval logic to a classmethod of the `Model` class because it was getting cumbersome to repeat this exact same logic in all actor implementations.

#### Other changes:
Add the `model.eval()` call in all actor `impl`, after model retrieval, for consistency across actor implementations.