### PR TITLE
Update PettingZoo version, make stylization/spelling consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simply clone the repo and start training.
 - Develop
   - [Development Setup](/docs/develop/development_setup.md)
   - [Docker](/docs/develop/docker.md)
-  - [Petting Zoo](/docs/develop/petting_zoo.md)
+  - [PettingZoo](/docs/develop/pettingzoo.md)
   - [Isaac Gym](/docs/develop/isaac_gym.md)
 - Deploy
   - [Tunnel unsing ngrok](/docs/deploy/tunnel_using_ngrok.md)
@@ -52,7 +52,7 @@ Simply clone the repo and start training.
 
 6. Depending on the environment you want to use, you might need to take additional steps.
 
-   - [Petting Zoo](/docs/develop/petting_zoo.md)
+   - [PettingZoo](/docs/develop/pettingzoo.md)
    - [Isaac Gym](/docs/develop/isaac_gym.md)
 
 7. In another terminal, launch a mlflow server on port 3000
@@ -96,7 +96,7 @@ Here are a few examples:
 
   This one is completely _headless_ (training doens't involve interaction with a human player). It will take a little while to run, you can monitor the progress using mlflow at <http://localhost:3000>
 
-- Launch an DQN self training run with the [Connect Four Petting Zoo environment](https://www.pettingzoo.ml/classic/connect_four)
+- Launch an DQN self training run with the [Connect Four PettingZoo environment](https://www.pettingzoo.ml/classic/connect_four)
 
   ```console
   $ python -m main +experiment=simple_dqn/connect_four
@@ -108,7 +108,7 @@ Here are a few examples:
   $ python -m main +experiment=simple_dqn/connect_four +run.hill_training_trials_ratio=0.05
   ```
 
-- Petting Zoo's [Atari Pong Environment](https://pettingzoo.farama.org/environments/atari/pong/)
+- PettingZoo's [Atari Pong Environment](https://pettingzoo.farama.org/environments/atari/pong/)
 
   Example #1: Play against RL agent
 

--- a/cogment_verse/specs/observation_space.py
+++ b/cogment_verse/specs/observation_space.py
@@ -192,7 +192,7 @@ class ObservationSpace:
         Shouldn't be called directly, prefer the factory function of EnvironmentSpecs.
         """
         if isinstance(space, Dict) and ("action_mask" in space.spaces):
-            # Check the observation space defines an action_mask "component" (like petting zoo does)
+            # Check the observation space defines an action_mask "component" (like PettingZoo does)
             assert "observation" in space.spaces
             assert len(space.spaces) == 2
 

--- a/docs/develop/pettingzoo.md
+++ b/docs/develop/pettingzoo.md
@@ -1,4 +1,4 @@
-## Petting Zoo
+## PettingZoo
 
 ### Atari Games
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 - Develop
   - [Development Setup](/docs/develop/development_setup.md)
   - [Docker](/docs/develop/docker.md)
-  - [Petting Zoo](/docs/develop/petting_zoo.md)
+  - [PettingZoo](/docs/develop/pettingzoo.md)
   - [Isaac Gym](/docs/develop/isaac_gym.md)
 - Deploy
   - [Tunnel unsing ngrok](/docs/deploy/tunnel_using_ngrok.md)

--- a/environments/pettingzoo_adapter.py
+++ b/environments/pettingzoo_adapter.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 
 def get_pz_player(observation: np.ndarray, actor_names: list) -> Tuple[str, int]:
-    """Get name and index for the petting zoo player. Note that it works specifically to Atari game"""
+    """Get name and index for the PettingZoo player. Note that it works specifically to Atari game"""
     num_agents = len(actor_names)
     indicators = observation[0, 0, -num_agents:]
     idx = int(np.where(indicators)[0])
@@ -120,7 +120,7 @@ class Environment(ABC):
 
 
 class ClassicEnvironment(Environment):
-    """Classic petting zoo e.g., connect four, Hanabi etc."""
+    """Classic PettingZoo e.g., connect four, Hanabi etc."""
 
     async def impl(self, environment_session):
         actors = environment_session.get_active_actors()
@@ -166,7 +166,7 @@ class ClassicEnvironment(Environment):
         rendered_frame = None
         if session_cfg.render:
             if "rgb_array" not in pz_env.metadata["render_modes"]:
-                log.warning(f"Petting Zoo environment [{self.env_class_name}] doesn't support rendering to pixels")
+                log.warning(f"PettingZoo environment [{self.env_class_name}] doesn't support rendering to pixels")
                 return
             rendered_frame = pz_env.render()
 
@@ -267,7 +267,7 @@ class AtariEnvironment(Environment):
         rendered_frame = None
         if session_cfg.render:
             if "rgb_array" not in pz_env.metadata["render_modes"]:
-                log.warning(f"Petting Zoo environment [{self.env_class_name}] doesn't support rendering to pixels")
+                log.warning(f"PettingZoo environment [{self.env_class_name}] doesn't support rendering to pixels")
                 return
             rendered_frame = pz_env.render()
 
@@ -349,7 +349,7 @@ class HumanFeedbackAtariEnvironment(Environment):
         # Render the pixel for UI
         rendered_frame = None
         if session_cfg.render and "rgb_array" not in pz_env.metadata["render_modes"]:
-            log.warning(f"Petting Zoo environment [{self.env_class_name}] doesn't support rendering to pixels")
+            log.warning(f"PettingZoo environment [{self.env_class_name}] doesn't support rendering to pixels")
             return
         rendered_frame = pz_env.render()
 


### PR DESCRIPTION
This PR closes https://github.com/cogment/cogment-verse/issues/142

* Update all usages of `petting zoo` or `Petting Zoo` to `PettingZoo` as that is the correct stylization
* Update PettingZoo version from 1.22.2 to 1.23.1

I've run the tests locally both before and after doing this change and it passed, so I think it shouldn't be an issue. 

Overcooked AI is in the process of updating their PettingZoo to the latest version (https://github.com/HumanCompatibleAI/overcooked_ai/pull/123), which I've been helping them on, so that shouldn't be an issue either.

Only issue I've encountered is after bumping the versions, reinstalling via requirements.txt I get this error for most of the packages (using pip in a conda virtual env):
`INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.`