### PR TITLE
Migrate to github version of overcooked_ai

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,6 @@ build_docker:
     - source .venv/bin/activate
     - pip install -r requirements.txt
     - pip install SuperSuit==3.7.0
-    - pip install -r overcooked_requirements.txt
   cache:
     # pip's cache
     - paths:

--- a/docs/develop/overcooked_ai.md
+++ b/docs/develop/overcooked_ai.md
@@ -1,11 +1,7 @@
 # Overcooked Environment
 
-You can use the overcooked environment integration with cogment-verse by installing a fork of the repository [overcooked_ai](git+https://github.com/wduguay-air/overcooked_ai.git).
+You can use the overcooked environment integration with cogment-verse. By default, the requirements.txt file includes the repository [overcooked_ai](git+https://github.com/wduguay-air/overcooked_ai.git).
 
-To install the forked repository, in addition to the original installation instructions, run the following command:
-```console
-pip install -r overcooked_requirements.txt
-```
 
 The integration uses the `play` run implementation as defined in
 `runs/play.py`

--- a/overcooked_requirements.txt
+++ b/overcooked_requirements.txt
@@ -1,2 +1,0 @@
-# For overcooked_ai
-git+https://github.com/wduguay-air/overcooked_ai.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ PettingZoo[atari,classic]~=1.22.2,<1.23
 tinyscaler~=1.2.4
 Gymnasium~=0.26.3
 AutoROM~=0.4.2
+git+https://github.com/HumanCompatibleAI/overcooked_ai.git
 
 
 # actors


### PR DESCRIPTION
The PR for a gym render method is merged on the overcooked_ai repo.
This update requirements to install the overcooked_ai repo from their github instead of a fork. Gets rid of separate requirements.

closes https://github.com/cogment/cogment-verse/issues/180